### PR TITLE
Restore pytest fixtures for recommendation tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,21 @@
-import pytest
-import sys
 import os
-from unittest.mock import Mock, patch
-import pandas as pd
+import sys
 from datetime import datetime, timedelta
+from unittest.mock import Mock, patch
+
+import pandas as pd
+import pytest
+import unittest.mock as _mock
+from unittest.mock import MagicMock
 
 # プロジェクトルートをパスに追加
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from models.recommendation import StockRecommendation
 
-import unittest.mock as _mock
-from unittest.mock import MagicMock
 
 _mock.Mock = MagicMock
+
 
 @pytest.fixture
 def mock_stock_data():
@@ -69,12 +72,24 @@ def generate_mock_stock_data(period="1y", symbol="7203", company_name="トヨタ
     return data
 
 
-# StockRecommendation class has been removed, temporarily disabling test
-# @pytest.fixture
-# def sample_recommendation():
-#     """Test recommendation data"""
-#     # from models.recommendation import StockRecommendation
-#     return None  # Removed: No longer needed after code refactoring
+@pytest.fixture
+def sample_recommendation() -> StockRecommendation:
+    """Provide a representative stock recommendation object for API tests."""
+
+    return StockRecommendation(
+        rank=1,
+        symbol="7203",
+        company_name="トヨタ自動車",
+        buy_timing="押し目買いを検討",
+        target_price=2300.0,
+        stop_loss=2000.0,
+        profit_target_1=2400.0,
+        profit_target_2=2500.0,
+        holding_period="1～2か月",
+        score=85.0,
+        current_price=2100.0,
+        recommendation_reason="テクニカル指標が上昇トレンドを示唆",
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- restore the missing standard-library imports in `tests/conftest.py`
- reinstate the `sample_recommendation` fixture so API tests receive valid data

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68d8d11a609483219017b89bc3d7b51a