### PR TITLE
Fix NameError in personal dashboard prediction error handling

### DIFF
--- a/app/personal_dashboard.py
+++ b/app/personal_dashboard.py
@@ -200,7 +200,7 @@ class PersonalDashboard:
                 "component_breakdown": prediction_result.get("component_breakdown", {}),
                 "timestamp": datetime.now().isoformat(),
                 "system_performance": f"{self.settings.prediction.achieved_accuracy}% Average Accuracy",
-except Exception:
+        except Exception as e:
             return {
                 "error": str(e),
                 "symbol": symbol,


### PR DESCRIPTION
## Summary
- capture the raised exception in `PersonalDashboard.get_89_precision_prediction` instead of using a bare clause
- return the existing error payload while ensuring the exception message is available without triggering a NameError

## Testing
- pytest tests/unit/test_systems/test_process_manager.py -k dashboard *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68d8deb04de083218db99a46e7d817f5