### PR TITLE
Ensure CI installs PyTorch CPU wheels and document optional ML deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     - name: Upgrade pip and install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install --index-url https://download.pytorch.org/whl/cpu \
+          torch==2.7.1+cpu torchaudio==2.7.1+cpu torchvision==0.22.1+cpu
         pip install -r requirements.txt
         pip install black==24.* flake8==7.* pytest==8.* pytest-mock
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -108,6 +108,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install --index-url https://download.pytorch.org/whl/cpu \
+          torch==2.7.1+cpu torchaudio==2.7.1+cpu torchvision==0.22.1+cpu
         pip install -r requirements.txt
         pip install pydocstyle interrogate
 
@@ -133,6 +135,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install --index-url https://download.pytorch.org/whl/cpu \
+          torch==2.7.1+cpu torchaudio==2.7.1+cpu torchvision==0.22.1+cpu
         pip install -r requirements.txt
         pip install pytest-benchmark
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 ```bash
 # 依存関係をインストール
 pip install -r requirements.txt
+
+# PyTorch系の重いライブラリが必要な場合のみ追加でインストール
+pip install -r requirements-ml.txt
 ```
 
 ## 使用方法

--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -1,0 +1,6 @@
+# Optional heavy machine learning dependencies.
+--index-url https://download.pytorch.org/whl/cpu
+torch==2.7.1+cpu
+# torchaudio and torchvision share the same index for CPU wheels.
+torchaudio==2.7.1+cpu
+torchvision==0.22.1+cpu

--- a/requirements.txt
+++ b/requirements.txt
@@ -426,9 +426,6 @@ toml==0.10.2
 tomli==2.2.1
 tomli_w==1.2.0
 tomlkit==0.13.3
-torch==2.7.1+cpu
-torchaudio==2.7.1+cpu
-torchvision==0.22.1+cpu
 tornado==6.5.1
 tqdm==4.67.1
 traitlets==5.14.3


### PR DESCRIPTION
## Summary
- install PyTorch CPU wheels directly from the official index in CI and code-quality workflows before other dependencies
- move the torch family into a dedicated optional requirements file and document how to install it

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d8f1396f008321b5b58ddbf25837fc