### PR TITLE
Add validator benchmark suite and optional pandas handling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,10 @@ import pytest
 import sys
 import os
 from unittest.mock import Mock, patch
-import pandas as pd
+try:
+    import pandas as pd
+except ModuleNotFoundError:  # pragma: no cover - optional dependency for tests
+    pd = None
 from datetime import datetime, timedelta
 
 # プロジェクトルートをパスに追加
@@ -31,6 +34,8 @@ def generate_mock_stock_data(period="1y", symbol="7203", company_name="トヨタ
     Returns:
         pd.DataFrame: Stock price data
     """
+    if pd is None:
+        pytest.skip("pandas is required for mock stock data fixtures")
     # Parse period parameter
     if period == "1y":
         days = 365
@@ -81,6 +86,8 @@ def generate_mock_stock_data(period="1y", symbol="7203", company_name="トヨタ
 def mock_yfinance():
     """Mock for yfinance"""
     with patch("yfinance.Ticker") as mock_ticker:
+        if pd is None:
+            pytest.skip("pandas is required for yfinance fixtures")
         mock_ticker_instance = Mock()
         mock_ticker_instance.history.return_value = pd.DataFrame(
             {

--- a/tests/performance/test_validator_bench.py
+++ b/tests/performance/test_validator_bench.py
@@ -1,0 +1,35 @@
+import random
+import string
+
+import pytest
+
+from utils.validators import sanitize_string, validate_email, validate_stock_symbol
+
+
+pytest.importorskip("pytest_benchmark")
+
+
+_ALPHABET = string.ascii_letters + string.digits + " -_.@"
+_RANDOM = random.Random(42)
+
+
+def _generate_payload(size: int) -> str:
+    return "".join(_RANDOM.choice(_ALPHABET) for _ in range(size))
+
+
+@pytest.mark.benchmark(group="validators")
+def test_sanitize_string_benchmark(benchmark):
+    payload = _generate_payload(5000)
+    benchmark(lambda: sanitize_string(payload, max_length=256))
+
+
+@pytest.mark.benchmark(group="validators")
+def test_validate_email_benchmark(benchmark):
+    payload = _generate_payload(64) + "@example.com"
+    benchmark(lambda: validate_email(payload))
+
+
+@pytest.mark.benchmark(group="validators")
+def test_validate_stock_symbol_benchmark(benchmark):
+    payload = "AAPL" * 10
+    benchmark(lambda: validate_stock_symbol(payload))

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -18,15 +18,6 @@ from .exceptions import (
     FileOperationError,
 )
 
-from .cache import (
-    DataCache,
-    cached,
-    cache_dataframe,
-    get_cache,
-    clear_cache,
-    cleanup_cache,
-)
-
 __all__ = [
     "ClStockException",
     "DataFetchError",
@@ -41,10 +32,32 @@ __all__ = [
     "ValidationError",
     "NetworkError",
     "FileOperationError",
-    "DataCache",
-    "cached",
-    "cache_dataframe",
-    "get_cache",
-    "clear_cache",
-    "cleanup_cache",
 ]
+
+try:
+    from .cache import (
+        DataCache,
+        cached,
+        cache_dataframe,
+        get_cache,
+        clear_cache,
+        cleanup_cache,
+    )
+except ModuleNotFoundError:  # pragma: no cover - optional pandas dependency
+    DataCache = None
+    cached = None
+    cache_dataframe = None
+    get_cache = None
+    clear_cache = None
+    cleanup_cache = None
+else:
+    __all__.extend(
+        [
+            "DataCache",
+            "cached",
+            "cache_dataframe",
+            "get_cache",
+            "clear_cache",
+            "cleanup_cache",
+        ]
+    )


### PR DESCRIPTION
## Summary
- add a pytest-benchmark performance suite for validator helpers under tests/performance
- make shared testing fixtures skip gracefully when pandas is unavailable
- guard utils package imports so pandas-heavy cache helpers are optional

## Testing
- pytest tests/performance *(skipped: pytest-benchmark plugin unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f13abf448321bec7381f5bf1588c