### PR TITLE
Use MLStockPredictor in API endpoints

### DIFF
--- a/tests/unit/test_models/test_predictor.py
+++ b/tests/unit/test_models/test_predictor.py
@@ -8,8 +8,8 @@ from unittest.mock import patch, Mock
 # from models.recommendation import StockRecommendation
 from models.recommendation import StockRecommendation
 
-# 新しいStockPredictorインターフェース
-from models_refactored.core.interfaces import StockPredictor
+# 互換レイヤーの具体的な予測器を利用
+from models.core import MLStockPredictor as StockPredictor
 
 # StockRecommendationは削除されたため、一時的にコメントアウト
 
@@ -21,9 +21,9 @@ class TestStockPredictor:
         """初期化のテスト"""
         predictor = StockPredictor()
         assert predictor.data_provider is not None
-        assert predictor.model is not None
+        assert predictor.model is None
         assert predictor.scaler is not None
-        assert predictor.is_trained is False
+        assert predictor.is_trained() is False
 
     @pytest.mark.unit
     def test_prepare_features(self, mock_stock_data):


### PR DESCRIPTION
## Summary
- instantiate the compatibility MLStockPredictor in the FastAPI endpoints and return a dedicated RecommendationResponse payload
- extend MLStockPredictor with scoring, recommendation, and ranking helpers used by the API and unit tests
- update API and predictor unit tests to authenticate requests and rely on the concrete MLStockPredictor implementation

## Testing
- pytest tests/unit/test_models/test_predictor.py
- pytest tests/unit/test_app/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68db3d2d727483219afecd7d775a377c