### PR TITLE
Handle single row stock data gracefully

### DIFF
--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -137,18 +137,23 @@ async def get_stock_data(
         technical_data = data_provider.calculate_technical_indicators(data)
         financial_metrics = data_provider.get_financial_metrics(symbol)
 
+        current_price = float(technical_data["Close"].iloc[-1])
+        price_change = 0.0
+        price_change_percent = 0.0
+
+        if len(technical_data) >= 2:
+            previous_close = technical_data["Close"].iloc[-2]
+            if not pd.isna(previous_close):
+                price_change = float(current_price - previous_close)
+                if previous_close != 0:
+                    price_change_percent = float(price_change / previous_close * 100)
+
         return {
             "symbol": symbol,
             "company_name": data_provider.jp_stock_codes.get(symbol, symbol),
-            "current_price": float(technical_data["Close"].iloc[-1]),
-            "price_change": float(
-                technical_data["Close"].iloc[-1] - technical_data["Close"].iloc[-2]
-            ),
-            "price_change_percent": float(
-                (technical_data["Close"].iloc[-1] - technical_data["Close"].iloc[-2])
-                / technical_data["Close"].iloc[-2]
-                * 100
-            ),
+            "current_price": current_price,
+            "price_change": price_change,
+            "price_change_percent": price_change_percent,
             "volume": int(technical_data["Volume"].iloc[-1]),
             "technical_indicators": {
                 "sma_20": (

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,0 +1,42 @@
+import pandas as pd
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock, patch
+
+from api.endpoints import router
+
+
+@patch("api.endpoints.StockDataProvider")
+def test_get_stock_data_single_row(mock_provider_cls):
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    mock_provider = MagicMock()
+    mock_provider.get_all_stock_symbols.return_value = {"7203": "Test Corp"}
+
+    single_row_df = pd.DataFrame(
+        {
+            "Close": [100.0],
+            "Volume": [1500],
+            "SMA_20": [None],
+            "SMA_50": [None],
+            "RSI": [None],
+            "MACD": [None],
+        },
+        index=pd.date_range("2024-01-01", periods=1),
+    )
+
+    mock_provider.get_stock_data.return_value = single_row_df
+    mock_provider.calculate_technical_indicators.return_value = single_row_df
+    mock_provider.get_financial_metrics.return_value = {}
+
+    mock_provider_cls.return_value = mock_provider
+
+    response = client.get("/stock/7203/data?period=1mo")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["price_change"] == 0.0
+    assert payload["price_change_percent"] == 0.0
+    assert payload["current_price"] == 100.0


### PR DESCRIPTION
## Summary
- guard the stock data endpoint price change calculations when only a single row of data is available
- add an API test that mocks the data provider to ensure the endpoint returns fallback values

## Testing
- pytest tests/test_api_endpoints.py

------
https://chatgpt.com/codex/tasks/task_e_68db7dc8ab5c8321b4ae6d706531930d