### PR TITLE
Rebuild StockDataProvider with offline-friendly tests

### DIFF
--- a/data/stock_data.py
+++ b/data/stock_data.py
@@ -1,14 +1,30 @@
+"""Stock market data utilities used throughout the project.
+
+The original implementation of this module was partially removed which left
+the application without a working ``StockDataProvider``.  This file restores a
+compact yet fully functional provider along with a deterministic fallback
+``yfinance`` stub so the rest of the codebase can continue to work in
+environments where the real dependency is unavailable (for example during
+tests).
+"""
+
+from __future__ import annotations
+
 import logging
 import os
-from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, Any, Iterable, List, Optional, Tuple
+from types import SimpleNamespace
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import pandas as pd
 
 from config.settings import get_settings
+from utils.cache import get_cache
 from utils.exceptions import DataFetchError
+
+
+logger = logging.getLogger(__name__)
 
 
 def _normalized_symbol_seed(symbol: str) -> int:
@@ -16,11 +32,345 @@ def _normalized_symbol_seed(symbol: str) -> int:
 
     return abs(hash(symbol)) % (2**32)
 
-# yfinance を try-except でインポート
-try:
-    import yfinance as yf
-except ModuleNotFoundError:
-    # yfinance が見つからない場合、ダミーのクラスを提供
-    class yf:
+
+def _period_to_days(period: str) -> int:
+    """Convert a Yahoo-finance period string to an approximate number of days."""
+
+    mapping = {
+        "1d": 1,
+        "5d": 5,
+        "1mo": 30,
+        "3mo": 90,
+        "6mo": 180,
+        "1y": 365,
+        "2y": 730,
+        "5y": 1825,
+        "10y": 3650,
+        "ytd": 365,
+        "max": 365 * 30,
+    }
+    return mapping.get(period, 120)
+
+
+try:  # pragma: no cover - exercised indirectly through tests
+    import yfinance as yf  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - hit in constrained envs
+
+    class _FallbackTicker:
+        """Minimal stand-in for ``yfinance.Ticker``.
+
+        It produces deterministic pseudo-random data so higher level code can
+        continue to operate without network access.
+        """
+
+        def __init__(self, symbol: str) -> None:
+            self.symbol = symbol
+            self._seed = _normalized_symbol_seed(symbol)
+            base_price = 80 + (self._seed % 100) / 2
+            self._info = {
+                "shortName": f"{symbol} Corp",
+                "marketCap": 100_000_000 + (self._seed % 10_000_000),
+                "forwardPE": 10.0 + (self._seed % 2000) / 200,
+                "trailingPE": 12.0 + (self._seed % 3000) / 200,
+                "dividendYield": 0.01 + ((self._seed // 5) % 200) / 10_000,
+                "beta": 1.0 + (self._seed % 500) / 1000,
+            }
+
+            self._fast_info = SimpleNamespace(
+                last_price=base_price + 1.5,
+                previous_close=base_price,
+                ten_day_average_volume=150_000 + (self._seed % 50_000),
+            )
+
+        @property
+        def info(self) -> Dict[str, float]:
+            return self._info
+
+        @property
+        def fast_info(self) -> SimpleNamespace:
+            return self._fast_info
+
+        def history(self, period: str = "1y", interval: str = "1d") -> pd.DataFrame:
+            length = max(5, _period_to_days(period))
+            end = datetime.utcnow().date()
+            index = pd.date_range(end - timedelta(days=length + 5), periods=length, freq="B")
+
+            base = 90 + (self._seed % 60)
+            variation = (self._seed % 13) - 6
+            close = pd.Series(
+                [base + variation * (i % 5) * 0.5 for i in range(len(index))],
+                index=index,
+                dtype="float",
+            )
+            open_ = close.shift(1, fill_value=close.iloc[0] - 0.5)
+            high = pd.concat([open_, close], axis=1).max(axis=1) + 0.3
+            low = pd.concat([open_, close], axis=1).min(axis=1) - 0.3
+            volume = pd.Series(
+                [100_000 + ((self._seed + i) % 20_000) for i in range(len(index))],
+                index=index,
+                dtype="int64",
+            )
+            return pd.DataFrame(
+                {"Open": open_, "High": high, "Low": low, "Close": close, "Volume": volume},
+                index=index,
+            )
+
+    class yf:  # type: ignore
         @staticmethod
-        def Ticker(symbol):
+        def Ticker(symbol: str) -> _FallbackTicker:
+            return _FallbackTicker(symbol)
+
+
+class StockDataProvider:
+    """Fetch and enrich historical stock data.
+
+    The provider favours cached and local data when available but can fall back
+    to ``yfinance`` for live downloads.  It also exposes helper utilities for
+    technical indicators and basic financial metrics.
+    """
+
+    def __init__(self) -> None:
+        settings = get_settings()
+        # Always keep codes sorted for deterministic behaviour
+        self.jp_stock_codes: Dict[str, str] = dict(sorted(settings.target_stocks.items()))
+        self.cache_ttl = int(os.getenv("CLSTOCK_STOCK_CACHE_TTL", "1800"))
+        default_data_dir = Path(os.getenv("CLSTOCK_DATA_DIR", Path(__file__).resolve().parent))
+        self._history_dirs: List[Path] = [default_data_dir / "historical", Path(settings.database.personal_portfolio_db).parent]
+        self._history_dirs = [path for path in self._history_dirs if path and path.exists()]
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def get_all_stock_symbols(self) -> List[str]:
+        """Return all supported stock symbols."""
+
+        return list(self.jp_stock_codes.keys())
+
+    def get_stock_data(self, symbol: str, period: str = "1y") -> pd.DataFrame:
+        """Fetch historical OHLCV data for *symbol*.
+
+        The result always contains the ``Symbol``, ``ActualTicker`` and
+        ``CompanyName`` columns in addition to the usual OHLCV fields.
+        """
+
+        cache_key = f"stock::{symbol}::{period}"
+        cache = get_cache()
+        cached = cache.get(cache_key)
+        if isinstance(cached, pd.DataFrame) and not cached.empty:
+            return cached
+
+        data: Optional[pd.DataFrame] = None
+        actual_ticker: Optional[str] = None
+
+        if self._should_use_local_first(symbol):
+            local = self._load_first_available_csv(symbol)
+            if local is not None:
+                data, actual_ticker = local
+
+        if data is None or data.empty:
+            data, actual_ticker = self._download_via_yfinance(symbol, period)
+
+        if data is None or data.empty:
+            raise DataFetchError(symbol, "No historical data available")
+
+        prepared = self._prepare_history_frame(data, symbol, actual_ticker)
+        cache.set(cache_key, prepared, ttl=self.cache_ttl)
+        return prepared
+
+    def get_multiple_stocks(
+        self, symbols: Iterable[str], period: str = "1y"
+    ) -> Dict[str, pd.DataFrame]:
+        """Fetch data for multiple symbols, skipping those that fail."""
+
+        result: Dict[str, pd.DataFrame] = {}
+        for symbol in symbols:
+            try:
+                result[symbol] = self.get_stock_data(symbol, period)
+            except DataFetchError:
+                logger.debug("Skipping symbol %s due to missing data", symbol)
+        return result
+
+    def calculate_technical_indicators(self, data: pd.DataFrame) -> pd.DataFrame:
+        """Calculate a selection of technical indicators."""
+
+        if data is None or data.empty:
+            return data.copy()
+
+        df = data.copy()
+        close = df["Close"].astype("float")
+        df["Close"] = close
+        high = df.get("High", close)
+        low = df.get("Low", close)
+
+        df["SMA_20"] = close.rolling(window=20, min_periods=1).mean()
+        df["SMA_50"] = close.rolling(window=50, min_periods=1).mean()
+
+        delta = close.diff()
+        gain = delta.clip(lower=0)
+        loss = -delta.clip(upper=0)
+        avg_gain = gain.rolling(window=14, min_periods=14).mean()
+        avg_loss = loss.rolling(window=14, min_periods=14).mean()
+        rs = avg_gain / avg_loss.replace({0: pd.NA})
+        df["RSI"] = (100 - (100 / (1 + rs))).fillna(100.0)
+
+        ema12 = close.ewm(span=12, adjust=False).mean()
+        ema26 = close.ewm(span=26, adjust=False).mean()
+        df["MACD"] = ema12 - ema26
+        df["MACD_Signal"] = df["MACD"].ewm(span=9, adjust=False).mean()
+
+        previous_close = close.shift(1)
+        true_range = pd.concat(
+            [
+                high - low,
+                (high - previous_close).abs(),
+                (low - previous_close).abs(),
+            ],
+            axis=1,
+        ).max(axis=1)
+        df["ATR"] = true_range.rolling(window=14, min_periods=1).mean()
+
+        return df
+
+    def get_financial_metrics(self, symbol: str) -> Dict[str, Optional[float]]:
+        """Return a dictionary with lightweight financial metrics."""
+
+        cache_key = f"financial::{symbol}"
+        cache = get_cache()
+        cached = cache.get(cache_key)
+        if isinstance(cached, dict):
+            return cached
+
+        metrics: Dict[str, Optional[float]] = {
+            "symbol": symbol,
+            "company_name": self.jp_stock_codes.get(symbol, symbol),
+            "market_cap": None,
+            "pe_ratio": None,
+            "dividend_yield": None,
+            "beta": None,
+            "last_price": None,
+            "previous_close": None,
+            "ten_day_average_volume": None,
+            "actual_ticker": None,
+        }
+
+        for ticker in self._ticker_formats(symbol):
+            try:
+                ticker_obj = yf.Ticker(ticker)
+                info = getattr(ticker_obj, "info", {}) or {}
+                fast = getattr(ticker_obj, "fast_info", None)
+
+                metrics.update(
+                    {
+                        "market_cap": info.get("marketCap", metrics["market_cap"]),
+                        "pe_ratio": info.get("forwardPE") or info.get("trailingPE"),
+                        "dividend_yield": info.get("dividendYield"),
+                        "beta": info.get("beta", metrics["beta"]),
+                    }
+                )
+
+                if fast is not None:
+                    metrics["last_price"] = getattr(fast, "last_price", metrics["last_price"])
+                    metrics["previous_close"] = getattr(
+                        fast, "previous_close", metrics["previous_close"]
+                    )
+                    metrics["ten_day_average_volume"] = getattr(
+                        fast, "ten_day_average_volume", metrics["ten_day_average_volume"]
+                    )
+
+                metrics["actual_ticker"] = ticker
+                break
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("Failed to retrieve financial metrics for %s via %s: %s", symbol, ticker, exc)
+                continue
+
+        cache.set(cache_key, metrics, ttl=self.cache_ttl)
+        return metrics
+
+    # ------------------------------------------------------------------
+    # Helper methods
+    # ------------------------------------------------------------------
+    def _ticker_formats(self, symbol: str) -> List[str]:
+        base = symbol.split(".")[0]
+        variants = [f"{base}.T", f"{base}.TO", base]
+        seen: Dict[str, None] = {}
+        result: List[str] = []
+        for candidate in variants:
+            if candidate not in seen:
+                seen[candidate] = None
+                result.append(candidate)
+        return result
+
+    def _should_use_local_first(self, symbol: str) -> bool:  # pragma: no cover - logic is trivial
+        prefer_local = os.getenv("CLSTOCK_PREFER_LOCAL_DATA", "0").lower()
+        return prefer_local in {"1", "true", "yes"}
+
+    def _load_first_available_csv(self, symbol: str) -> Optional[Tuple[pd.DataFrame, str]]:
+        for ticker in self._ticker_formats(symbol):
+            filename = f"{ticker}.csv"
+            for directory in self._history_dirs:
+                candidate = directory / filename
+                if candidate.exists():
+                    try:
+                        df = pd.read_csv(candidate, index_col=0, parse_dates=True)
+                        return df, ticker
+                    except Exception as exc:  # pragma: no cover - disk errors
+                        logger.debug("Failed to load local CSV %s: %s", candidate, exc)
+        return None
+
+    def _download_via_yfinance(self, symbol: str, period: str) -> Tuple[pd.DataFrame, Optional[str]]:
+        last_error: Optional[Exception] = None
+        for ticker in self._ticker_formats(symbol):
+            try:
+                ticker_obj = yf.Ticker(ticker)
+                history = ticker_obj.history(period=period)
+                if isinstance(history, pd.DataFrame) and not history.empty:
+                    return history, ticker
+            except Exception as exc:  # pragma: no cover - depends on yfinance
+                last_error = exc
+                logger.debug("Failed to download %s via yfinance: %s", ticker, exc)
+        if last_error:
+            logger.warning("All yfinance attempts failed for %s: %s", symbol, last_error)
+        return pd.DataFrame(), None
+
+    def _prepare_history_frame(
+        self, data: pd.DataFrame, symbol: str, actual_ticker: Optional[str]
+    ) -> pd.DataFrame:
+        df = data.copy()
+        if not isinstance(df.index, pd.DatetimeIndex):
+            df.index = pd.to_datetime(df.index)
+        df.sort_index(inplace=True)
+
+        for column in ["Open", "High", "Low", "Close", "Volume"]:
+            if column not in df:
+                df[column] = pd.NA
+
+        df["Close"] = pd.to_numeric(df["Close"], errors="coerce")
+        df["Close"] = df["Close"].ffill().bfill()
+        for column in ["Open", "High", "Low"]:
+            df[column] = pd.to_numeric(df[column], errors="coerce")
+            df[column] = df[column].fillna(df["Close"])
+
+        if "Volume" in df:
+            df["Volume"] = (
+                pd.to_numeric(df["Volume"], errors="coerce").fillna(0).astype("int64")
+            )
+
+        df["Symbol"] = symbol
+        df["ActualTicker"] = actual_ticker or self._ticker_formats(symbol)[0]
+        df["CompanyName"] = self.jp_stock_codes.get(symbol, symbol)
+        return df
+
+
+# Backwards compatibility helper -------------------------------------------------
+
+_stock_data_provider: Optional[StockDataProvider] = None
+
+
+def get_stock_data_provider() -> StockDataProvider:
+    """Singleton-style access used by legacy modules."""
+
+    global _stock_data_provider
+    if _stock_data_provider is None:
+        _stock_data_provider = StockDataProvider()
+    return _stock_data_provider
+

--- a/tests/integration/test_api_stock_data_route.py
+++ b/tests/integration/test_api_stock_data_route.py
@@ -1,0 +1,80 @@
+"""Integration test hitting the stock data route implementation directly."""
+
+from __future__ import annotations
+
+import math
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from api import endpoints
+
+
+class _MemoryCache:
+    def __init__(self) -> None:
+        self._storage = {}
+
+    def get(self, key):
+        return self._storage.get(key)
+
+    def set(self, key, value, ttl=None):
+        self._storage[key] = value
+        return True
+
+
+def _build_history() -> pd.DataFrame:
+    idx = pd.date_range("2024-01-01", periods=20, freq="D")
+    base = pd.Series(range(120, 140), dtype="float", index=idx)
+    # introduce a small dip to avoid flat RSI calculations
+    base.iloc[10:12] = base.iloc[10:12] - 2
+    return pd.DataFrame(
+        {
+            "Open": base + 0.5,
+            "High": base + 1.0,
+            "Low": base - 1.0,
+            "Close": base,
+            "Volume": pd.Series([20_000 + i * 50 for i in range(20)], dtype="int", index=idx),
+        }
+    )
+
+
+def _ticker_stub(symbol: str) -> SimpleNamespace:
+    frame = _build_history()
+    ticker = SimpleNamespace()
+    ticker.symbol = symbol
+    ticker.info = {
+        "shortName": f"{symbol} Incorporated",
+        "marketCap": 987_654_321,
+        "forwardPE": 14.2,
+        "trailingPE": 16.1,
+        "dividendYield": 0.015,
+        "beta": 1.05,
+    }
+    ticker.fast_info = SimpleNamespace(
+        last_price=float(frame["Close"].iloc[-1]),
+        previous_close=float(frame["Close"].iloc[-2]),
+        ten_day_average_volume=float(frame["Volume"].tail(10).mean()),
+    )
+
+    def _history(period: str = "1y", interval: str = "1d") -> pd.DataFrame:
+        ticker.last_request = {"period": period, "interval": interval}
+        return frame.copy()
+
+    ticker.history = _history
+    return ticker
+
+
+@pytest.mark.asyncio()
+async def test_stock_route_works_with_real_provider() -> None:
+    with patch("data.stock_data.get_cache", return_value=_MemoryCache()), patch(
+        "data.stock_data.yf.Ticker", side_effect=_ticker_stub
+    ):
+        payload = await endpoints.get_stock_data("7203", "1mo")
+
+    assert payload["symbol"] == "7203"
+    assert payload["company_name"]
+    assert not math.isnan(payload["current_price"])
+    assert "technical_indicators" in payload
+    assert "financial_metrics" in payload

--- a/tests/unit/test_data/test_stock_data_provider_rebuild.py
+++ b/tests/unit/test_data/test_stock_data_provider_rebuild.py
@@ -1,0 +1,120 @@
+"""Unit tests for the reconstructed :mod:`data.stock_data` module.
+
+The tests exercise the public API that other parts of the project rely on
+while ensuring we never perform real network or filesystem I/O.  They work in
+concert with the fallback ``yf.Ticker`` stub that will be implemented in
+``data/stock_data.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Dict, List
+
+import pandas as pd
+import pytest
+from unittest.mock import patch
+
+from data.stock_data import StockDataProvider
+
+
+class _MemoryCache:
+    """Simple in-memory cache used to short-circuit disk access in tests."""
+
+    def __init__(self) -> None:
+        self._storage: Dict[str, object] = {}
+
+    def get(self, key: str) -> object | None:
+        return self._storage.get(key)
+
+    def set(self, key: str, value: object, ttl: int | None = None) -> bool:
+        self._storage[key] = value
+        return True
+
+
+@pytest.fixture()
+def history_frame() -> pd.DataFrame:
+    """Return a deterministic OHLCV frame used across the tests."""
+
+    idx = pd.date_range("2024-01-01", periods=30, freq="D")
+    return pd.DataFrame(
+        {
+            "Open": pd.Series(range(100, 130), dtype="float"),
+            "High": pd.Series(range(101, 131), dtype="float"),
+            "Low": pd.Series(range(99, 129), dtype="float"),
+            "Close": pd.Series(range(100, 130), dtype="float"),
+            "Volume": pd.Series([10_000 + i * 100 for i in range(30)], dtype="int"),
+        },
+        index=idx,
+    )
+
+
+@pytest.fixture()
+def ticker_factory(history_frame: pd.DataFrame):
+    """Factory returning lightweight ``yfinance.Ticker`` stand-ins."""
+
+    def _factory(symbol: str) -> SimpleNamespace:
+        ticker = SimpleNamespace()
+        ticker.symbol = symbol
+        ticker.info = {
+            "shortName": f"{symbol} Corp",
+            "marketCap": 123_456_789,
+            "forwardPE": 15.0,
+            "trailingPE": 16.5,
+            "dividendYield": 0.012,
+        }
+        ticker.fast_info = SimpleNamespace(
+            last_price=history_frame["Close"].iloc[-1],
+            previous_close=history_frame["Close"].iloc[-2],
+            ten_day_average_volume=history_frame["Volume"].tail(10).mean(),
+        )
+
+        def _history(period: str = "1y", interval: str = "1d") -> pd.DataFrame:
+            ticker.last_history_args = {"period": period, "interval": interval}
+            return history_frame.copy()
+
+        ticker.history = _history
+        return ticker
+
+    return _factory
+
+
+def test_get_stock_data_uses_cache(history_frame: pd.DataFrame, ticker_factory) -> None:
+    provider = StockDataProvider()
+    cache = _MemoryCache()
+    ticker_calls: List[str] = []
+
+    def _ticker_side_effect(symbol: str):
+        ticker_calls.append(symbol)
+        return ticker_factory(symbol)
+
+    with patch("data.stock_data.get_cache", return_value=cache), patch(
+        "data.stock_data.yf.Ticker", side_effect=_ticker_side_effect
+    ):
+        first = provider.get_stock_data("7203", "1mo")
+        second = provider.get_stock_data("7203", "1mo")
+
+    assert ticker_calls == ["7203.T"]  # only the first call should touch yfinance
+    assert list(first.columns[:5]) == ["Open", "High", "Low", "Close", "Volume"]
+    assert {"Symbol", "ActualTicker", "CompanyName"}.issubset(first.columns)
+    assert first.equals(second)
+    assert first["Symbol"].unique().tolist() == ["7203"]
+    assert first["ActualTicker"].iloc[-1] == "7203.T"
+
+
+def test_calculate_technical_indicators_schema(history_frame: pd.DataFrame) -> None:
+    provider = StockDataProvider()
+    enriched = provider.calculate_technical_indicators(history_frame)
+
+    required = {"SMA_20", "SMA_50", "RSI", "MACD", "MACD_Signal", "ATR"}
+    assert required.issubset(enriched.columns)
+    assert enriched.index.equals(history_frame.index)
+
+
+def test_get_all_stock_symbols_sorted() -> None:
+    provider = StockDataProvider()
+    symbols = provider.get_all_stock_symbols()
+
+    assert isinstance(symbols, list)
+    assert symbols == sorted(symbols)
+    assert "7203" in symbols


### PR DESCRIPTION
## Summary
- reconstruct `data/stock_data.py` with a deterministic yfinance fallback and the full `StockDataProvider` helper surface (caching, downloads, indicators, metrics)
- add unit tests that patch yfinance and caching to exercise `get_stock_data`, indicator calculation, and symbol listing without real I/O
- add an async integration test that calls the `/api/v1/stock/{symbol}/data` route and confirms the real provider works offline

## Testing
- pytest tests/unit/test_data/test_stock_data_provider_rebuild.py
- pytest tests/integration/test_api_stock_data_route.py

------
https://chatgpt.com/codex/tasks/task_e_68dbc961c9588321848c7307caa9f26f