### PR TITLE
Align process manager services with maintained entrypoints

### DIFF
--- a/clstock_cli.py
+++ b/clstock_cli.py
@@ -247,11 +247,24 @@ def optimize():
     """最適化システムの実行"""
     manager = get_process_manager()
 
-    click.echo("[最適化] 最適化システム起動...")
+    click.echo("[最適化] ウルトラ最適化システム起動...")
     if manager.start_service("optimized_system"):
-        click.echo("[成功] 最適化システム起動完了")
+        click.echo("[成功] ウルトラ最適化システム起動完了")
     else:
         click.echo("[失敗] 最適化システム起動失敗")
+        sys.exit(1)
+
+
+@system.command()
+def integration():
+    """統合テストサービスの実行"""
+    manager = get_process_manager()
+
+    click.echo("🔬 統合テストサービス起動...")
+    if manager.start_service("integration_test"):
+        click.echo("[成功] 統合テストサービス起動完了")
+    else:
+        click.echo("[失敗] 統合テストサービス起動失敗")
         sys.exit(1)
 
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -188,8 +188,7 @@ class ProcessConfig:
             "demo_trading": 5,
             "investment_system": 8,
             "deep_learning": 3,
-            "ensemble_test": 2,
-            "clstock_main": 7,
+            "integration_test": 2,
             "optimized_system": 6,
             "selective_system": 4,
         }

--- a/systems/process_manager.py
+++ b/systems/process_manager.py
@@ -110,34 +110,28 @@ class ProcessManager:
             ),
             "investment_system": ProcessInfo(
                 name="investment_system",
-                command="python investment_system.py",
+                command="python full_auto_system.py",
                 working_dir=str(PROJECT_ROOT),
             ),
             "deep_learning": ProcessInfo(
                 name="deep_learning",
-                command="python big_data_deep_learning.py",
+                command="python research/big_data_deep_learning.py",
                 working_dir=str(PROJECT_ROOT),
             ),
-            "ensemble_test": ProcessInfo(
-                name="ensemble_test",
-                command="python advanced_ensemble_test.py",
-                working_dir=str(PROJECT_ROOT),
-                auto_restart=False,
-            ),
-            "clstock_main": ProcessInfo(
-                name="clstock_main",
-                command="python clstock_main.py --integrated 7203",
+            "integration_test": ProcessInfo(
+                name="integration_test",
+                command="python integration_test_enhanced.py",
                 working_dir=str(PROJECT_ROOT),
                 auto_restart=False,
             ),
             "optimized_system": ProcessInfo(
                 name="optimized_system",
-                command="python optimized_investment_system.py",
+                command="python ultra_optimized_system.py",
                 working_dir=str(PROJECT_ROOT),
             ),
             "selective_system": ProcessInfo(
                 name="selective_system",
-                command="python super_selective_system.py",
+                command="python performance_test_enhanced.py",
                 working_dir=str(PROJECT_ROOT),
             ),
         }

--- a/tests/unit/test_systems/test_process_manager.py
+++ b/tests/unit/test_systems/test_process_manager.py
@@ -27,6 +27,7 @@ class TestProcessManager:
         assert "dashboard" in pm.processes
         assert "demo_trading" in pm.processes
         assert "investment_system" in pm.processes
+        assert "integration_test" in pm.processes
 
         # Check dashboard service configuration
         dashboard = pm.processes["dashboard"]
@@ -34,6 +35,21 @@ class TestProcessManager:
         assert dashboard.name == "dashboard"
         assert dashboard.command == "python app/personal_dashboard.py"
         assert dashboard.status == ProcessStatus.STOPPED
+
+        investment = pm.processes["investment_system"]
+        assert investment.command == "python full_auto_system.py"
+
+        deep_learning = pm.processes["deep_learning"]
+        assert deep_learning.command == "python research/big_data_deep_learning.py"
+
+        integration = pm.processes["integration_test"]
+        assert integration.command == "python integration_test_enhanced.py"
+
+        optimized = pm.processes["optimized_system"]
+        assert optimized.command == "python ultra_optimized_system.py"
+
+        selective = pm.processes["selective_system"]
+        assert selective.command == "python performance_test_enhanced.py"
 
     def test_process_info_initialization(self):
         """Test ProcessInfo dataclass initialization."""
@@ -177,3 +193,21 @@ class TestProcessManager:
         assert "memory_percent" in resources
         assert resources["cpu_percent"] == 25.5
         assert resources["memory_percent"] == 60.0
+
+    def test_default_service_scripts_exist(self):
+        """Ensure default service commands reference existing scripts."""
+        import shlex
+        from pathlib import Path
+
+        pm = ProcessManager()
+
+        for service in pm.list_services():
+            command_parts = shlex.split(service.command)
+            assert (
+                len(command_parts) >= 2
+            ), f"Command for {service.name} must include script path"
+
+            script_path = Path(service.working_dir) / command_parts[1]
+            assert script_path.exists(), (
+                f"Script for {service.name} not found: {script_path}"
+            )

--- a/tests/unit/test_systems/test_process_manager_comprehensive.py
+++ b/tests/unit/test_systems/test_process_manager_comprehensive.py
@@ -37,8 +37,7 @@ class TestProcessManagerComprehensive:
             "demo_trading",
             "investment_system",
             "deep_learning",
-            "ensemble_test",
-            "clstock_main",
+            "integration_test",
             "optimized_system",
             "selective_system",
         ]


### PR DESCRIPTION
## Summary
- update the default process manager services to point at maintained scripts and add an integration test service
- adjust CLI messaging and settings priorities to reflect the refreshed service catalog
- extend unit coverage to assert that each default service references an existing script on disk

## Testing
- pytest tests/unit/test_systems/test_process_manager.py::TestProcessManager::test_default_service_scripts_exist -q *(fails: ImportError in tests/conftest.py due to IndentationError in data/stock_data.py)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd123ad5c8321a71794de3811796b