### PR TITLE
Handle missing future returns as neutral

### DIFF
--- a/models/core.py
+++ b/models/core.py
@@ -376,7 +376,8 @@ class MLStockPredictor(CacheablePredictor):
         if close is None:
             return pd.Series(dtype=float)
         future_returns = df[close].pct_change(periods=5).shift(-5) * 100.0
-        return future_returns.clip(-20, 20).fillna(50.0) + 50
+        future_returns = future_returns.clip(-20, 20).fillna(0.0)
+        return future_returns + 50
 
     def prepare_dataset(self, symbols: List[str]) -> pd.DataFrame:
         if not symbols:

--- a/tests/unit/test_models/test_core.py
+++ b/tests/unit/test_models/test_core.py
@@ -108,6 +108,20 @@ class TestMLStockPredictor:
         valid_scores = scores.dropna()
         assert all(0 <= score <= 100 for score in valid_scores)
 
+    def test_calculate_future_performance_score_with_insufficient_lookahead(self):
+        """Rows without lookahead data should receive neutral scores."""
+        predictor = MLStockPredictor()
+        data = pd.DataFrame(
+            {
+                "Close": [100.0, 101.0, 102.0],
+            },
+            index=pd.date_range("2023-01-01", periods=3, freq="D"),
+        )
+
+        scores = predictor._calculate_future_performance_score(data)
+
+        assert list(scores) == [50.0, 50.0, 50.0]
+
     @patch("models.core.MLStockPredictor.data_provider")
     def test_prepare_dataset_empty_symbols(self, mock_data_provider):
         """Test prepare_dataset with empty symbols list."""


### PR DESCRIPTION
## Summary
- treat missing five-day return calculations as neutral before adding the scoring offset in `MLStockPredictor`
- add a unit test to ensure rows without sufficient lookahead data receive a neutral score of 50

## Testing
- `pytest tests/unit/test_models/test_core.py::TestMLStockPredictor::test_calculate_future_performance_score_with_insufficient_lookahead`
- `pytest` *(fails: numerous pre-existing errors across unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe15620888321a86ea7cec9d7aa57