### PR TITLE
Remove default API test tokens and document configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,25 @@ python main.py
 - `GET /secure/stock/{symbol}/data` - セキュアな株価データ取得（認証必要）
 - `GET /secure/analysis/{symbol}` - 高度な市場分析（管理者権限必要）
 
+#### API 認証トークンの設定
+
+運用環境では以下の環境変数を必ず設定し、デフォルトの固定トークンは使用しないでください。
+
+```bash
+export API_ADMIN_TOKEN="<強力な管理者トークン>"
+export API_USER_TOKEN="<一般ユーザー用トークン>"
+```
+
+必要に応じて FastAPI のセキュアエンドポイントに追加のトークンを紐付けたい場合は `config/secrets.py` や `CLSTOCK_DEV_KEY`/`CLSTOCK_ADMIN_KEY` などの既存設定を活用できます。
+
+ローカル開発やテストで旧来の固定トークン（`admin_token_secure_2024` など）を利用したい場合のみ、明示的に以下のフラグを有効化してください。
+
+```bash
+export API_ENABLE_TEST_TOKENS=1  # 本番環境では絶対に有効化しない
+```
+
+このフラグが無効な状態では固定トークンは一切受け付けられず、環境変数で登録したトークンのみが使用されます。
+
 ## 主要技術
 
 - 🧠 **87%精度突破統合システム** - メタラーニング・DQN強化学習統合

--- a/tests/unit/test_app/test_api.py
+++ b/tests/unit/test_app/test_api.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import patch, Mock
@@ -19,9 +21,12 @@ class TestAPI:
     @pytest.fixture
     def client(self):
         """テストクライアントのセットアップ"""
-        client = TestClient(app)
-        client.headers.update({"Authorization": "Bearer admin_token_secure_2024"})
-        return client
+        with patch.dict(
+            os.environ, {"API_ADMIN_TOKEN": "admin_token_secure_2024"}, clear=False
+        ):
+            client = TestClient(app)
+            client.headers.update({"Authorization": "Bearer admin_token_secure_2024"})
+            yield client
 
     @pytest.mark.api
     def test_root_endpoint(self, client):


### PR DESCRIPTION
## Summary
- ensure api.security.verify_token only trusts tokens provided via environment variables or explicitly enabled test tokens
- update API security tests to inject tokens through patched environment variables and adjust secure endpoint mocks
- document the new authentication configuration flow in the README for production and local testing

## Testing
- pytest tests/test_api_security.py
- pytest tests/unit/test_app/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68dbe160130c8321a95e98f183581ccf