### PR TITLE
Validate stock data query parameters

### DIFF
--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -40,3 +40,16 @@ def test_get_stock_data_single_row(mock_provider_cls):
     assert payload["price_change"] == 0.0
     assert payload["price_change_percent"] == 0.0
     assert payload["current_price"] == 100.0
+
+
+@patch("api.endpoints.StockDataProvider")
+def test_get_stock_data_invalid_period_returns_400(mock_provider_cls):
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.get("/stock/7203/data?period=invalid")
+
+    assert response.status_code == 400
+    assert "Invalid period" in response.json()["detail"]
+    mock_provider_cls.assert_not_called()


### PR DESCRIPTION
## Summary
- validate stock data requests with validate_stock_symbol and validate_period before hitting the provider
- surface validation and data fetch issues as 400 errors for the stock data endpoint
- add an API test ensuring an invalid period returns HTTP 400

## Testing
- pytest tests/test_api_endpoints.py

------
https://chatgpt.com/codex/tasks/task_e_68dbe159c23c83219d1ad9af10502112