### PR TITLE
Fix test token configuration handling

### DIFF
--- a/api/security.py
+++ b/api/security.py
@@ -116,7 +116,7 @@ rate_limit_storage: Dict[str, Dict[str, int]] = {}
 
 API_KEYS: Dict[str, str] = _initialize_api_keys()
 ALLOW_TEST_TOKENS = False
-TEST_TOKENS: Dict[str, str] = {}
+TEST_TOKENS: Dict[str, str] = dict(_TEST_TOKENS)
 
 
 def configure_security(
@@ -221,6 +221,9 @@ def verify_api_key(
 def _should_include_test_tokens() -> bool:
     """テスト用トークンを許可するかを判定"""
 
+    if ALLOW_TEST_TOKENS:
+        return True
+
     flag_value = os.getenv(_TEST_TOKEN_FLAG, "").strip().lower()
     return flag_value in {"1", "true", "yes", "on"}
 
@@ -234,10 +237,8 @@ def _build_allowed_tokens() -> Dict[str, str]:
     tokens.update(env_tokens)
 
     if _should_include_test_tokens():
-        logger.warning(
-            "Test tokens enabled via environment flag. Do not use in production."
-        )
-        tokens.update(_TEST_TOKENS)
+        logger.warning("Test tokens enabled. Do not use in production.")
+        tokens.update(TEST_TOKENS)
 
     return tokens
 

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -154,6 +154,28 @@ class TestAPIAuthentication:
 
         assert len(missing_warnings_after_second_call) == 2
 
+    def test_configure_security_custom_test_tokens(self):
+        """configure_security で指定したテストトークンが利用可能になる"""
+
+        original_test_tokens = dict(security_module.TEST_TOKENS)
+        original_allow_flag = security_module.ALLOW_TEST_TOKENS
+
+        try:
+            security_module.configure_security(
+                test_tokens={"custom_test_token": "qa"},
+                enable_test_tokens=True,
+            )
+
+            if hasattr(security_module, "reset_env_token_cache"):
+                security_module.reset_env_token_cache()
+
+            assert verify_token("custom_test_token") == "qa"
+        finally:
+            security_module.configure_security(
+                test_tokens=original_test_tokens,
+                enable_test_tokens=original_allow_flag,
+            )
+
 
 class TestAPIEndpointSecurity:
     """APIエンドポイントセキュリティのテスト"""


### PR DESCRIPTION
## Summary
- ensure `_build_allowed_tokens` respects the configurable `TEST_TOKENS` mapping
- allow `configure_security` to enable test tokens without requiring the environment flag
- extend API security tests to cover custom test token configuration

## Testing
- ⚠️ `pytest tests/test_api_security.py` *(fails: ImportError: Install pandas before running ClStock.)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5bd0880483219bf9e0b22bdf9503