### PR TITLE
Redact sensitive token values in warning logs

### DIFF
--- a/api/security.py
+++ b/api/security.py
@@ -24,6 +24,26 @@ _TEST_TOKENS = {
     "user_token_basic_2024": "user",
 }
 
+
+def _redact_secret(value: Optional[str], visible: int = 4) -> str:
+    """Create a redacted representation for sensitive values."""
+
+    if value is None:
+        return "<none>"
+
+    if value == "":
+        return "<empty>"
+
+    visible = max(1, visible)
+
+    if len(value) <= visible:
+        return "***"
+
+    if len(value) <= visible * 2:
+        return f"{value[:visible]}***"
+
+    return f"{value[:visible]}***{value[-visible:]}"
+
 def reset_env_token_cache() -> None:
     """Reset cached environment token values and warning tracking."""
 
@@ -210,7 +230,10 @@ def verify_api_key(
     token = credentials.credentials
 
     if token not in API_KEYS:
-        logger.warning(f"Invalid API key attempt: {token}")
+        logger.warning(
+            "Invalid API key attempt: %s",
+            _redact_secret(token),
+        )
         raise HTTPException(status_code=401, detail="Invalid API key")
 
     user_type = API_KEYS[token]
@@ -250,7 +273,10 @@ def verify_token(token: str) -> str:
     allowed_tokens = _build_allowed_tokens()
 
     if token not in allowed_tokens:
-        logger.warning(f"Invalid token attempt: {token}")
+        logger.warning(
+            "Invalid token attempt: %s",
+            _redact_secret(token),
+        )
         raise HTTPException(status_code=401, detail="Invalid token")
 
     user_type = allowed_tokens[token]


### PR DESCRIPTION
## Summary
- add a reusable helper to redact sensitive values before logging warning messages in `api/security.py`
- update API security tests to capture logger output and assert tokens/API keys are redacted in warnings

## Testing
- pytest tests/test_api_security.py::TestAPIAuthentication::test_verify_token_logs_redacted_value tests/test_api_security.py::TestAPIAuthentication::test_verify_api_key_logs_redacted_value

------
https://chatgpt.com/codex/tasks/task_e_68dc5bd5ee5c8321b26351821e628d16