### PR TITLE
Allow configure_security to enable test tokens

### DIFF
--- a/api/security.py
+++ b/api/security.py
@@ -221,6 +221,9 @@ def verify_api_key(
 def _should_include_test_tokens() -> bool:
     """テスト用トークンを許可するかを判定"""
 
+    if ALLOW_TEST_TOKENS:
+        return True
+
     flag_value = os.getenv(_TEST_TOKEN_FLAG, "").strip().lower()
     return flag_value in {"1", "true", "yes", "on"}
 

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -112,6 +112,24 @@ class TestAPIAuthentication:
         result = verify_token(custom_token)
         assert result == "user"
 
+    def test_verify_token_accepts_test_token_when_enabled(self, monkeypatch):
+        """テストトークン有効化時に_TEST_TOKENSが使用されることを確認"""
+        from fastapi import HTTPException
+
+        # 環境フラグは無効化しておく
+        monkeypatch.delenv("API_ENABLE_TEST_TOKENS", raising=False)
+
+        # 明示的にテストトークンを無効化
+        security_module.configure_security(enable_test_tokens=False)
+
+        with pytest.raises(HTTPException):
+            verify_token("admin_token_secure_2024")
+
+        # テストトークンを有効化すると検証が通るはず
+        security_module.configure_security(enable_test_tokens=True)
+
+        assert verify_token("admin_token_secure_2024") == "administrator"
+
     def test_verify_token_missing_env_logs_warning_once(self, monkeypatch):
         """Missing environment variables should only emit one warning each"""
 


### PR DESCRIPTION
## Summary
- allow `_should_include_test_tokens` to respect in-process configuration as well as the environment flag
- add a regression test verifying that enabling test tokens via `configure_security` allows test tokens to pass verification

## Testing
- `pytest tests/test_api_security.py::TestAPIAuthentication::test_verify_token_accepts_test_token_when_enabled -q` *(fails: ImportError: Install pandas before running ClStock.)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5bd89d008321a7c0c832fb00a3b3