### PR TITLE
Fix executor shutdown timeout handling in ProcessManager

### DIFF
--- a/systems/process_manager.py
+++ b/systems/process_manager.py
@@ -13,7 +13,7 @@ import signal
 import concurrent.futures
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 from dataclasses import dataclass, field
 from enum import Enum
 
@@ -80,6 +80,8 @@ class ProcessManager:
         )
         # プロセスプールの追加
         self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=10)
+        self._executor_futures_lock = threading.Lock()
+        self._executor_futures: Set[concurrent.futures.Future] = set()
         # リソース制限の追加
         self._resource_limit_lock = threading.Lock()
         self._current_cpu_usage = 0.0
@@ -306,6 +308,7 @@ class ProcessManager:
                     # リソース制限チェック
                     if self._check_resource_limits(self.processes[name]):
                         future = self._executor.submit(self.start_service, name)
+                        self._register_executor_future(future)
                         futures[future] = name
                     else:
                         results[name] = False
@@ -576,11 +579,37 @@ class ProcessManager:
         try:
             logger.info("グレースフルシャットダウン開始")
             self.stop_all_services(force=True)
-            
+
             # 並列実行プールのシャットダウン
-            logger.info("並列実行プールをシャットダウン")
-            self._executor.shutdown(wait=True, timeout=10)
-            
+            logger.info("並列実行プールをシャットダウン (最大10秒待機)")
+            shutdown_timeout = 10
+            deadline = time.monotonic() + shutdown_timeout
+            pending_futures = self._collect_executor_futures()
+            all_completed = True
+
+            for future in pending_futures:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    all_completed = False
+                    logger.warning("並列タスクの完了待機がタイムアウトしました")
+                    break
+
+                try:
+                    future.result(timeout=remaining)
+                except concurrent.futures.TimeoutError:
+                    logger.warning("並列タスクの完了待機がタイムアウトしました")
+                    all_completed = False
+                    break
+                except Exception as future_error:
+                    logger.error(f"並列タスクの実行中にエラー: {future_error}")
+
+            if all_completed:
+                self._executor.shutdown(wait=True)
+            else:
+                self._executor.shutdown(wait=False)
+                # タイムアウトした未完了タスクはキャンセルを試みる
+                self._cancel_pending_futures()
+
             logger.info("全サービス停止完了、プロセス終了")
             # シャットダウンイベントをクリア
             self._shutdown_event.clear()
@@ -589,6 +618,31 @@ class ProcessManager:
         except Exception as e:
             logger.error(f"シャットダウン中にエラー発生: {e}")
             os._exit(1)
+
+    def _register_executor_future(self, future: concurrent.futures.Future) -> None:
+        """シャットダウン時に待機するため、実行中の Future を登録する"""
+
+        with self._executor_futures_lock:
+            self._executor_futures.add(future)
+
+        def _remove_completed(fut: concurrent.futures.Future) -> None:
+            with self._executor_futures_lock:
+                self._executor_futures.discard(fut)
+
+        future.add_done_callback(_remove_completed)
+
+    def _collect_executor_futures(self) -> List[concurrent.futures.Future]:
+        """現在登録されている Future のスナップショットを取得"""
+
+        with self._executor_futures_lock:
+            return list(self._executor_futures)
+
+    def _cancel_pending_futures(self) -> None:
+        """未完了の Future をキャンセル"""
+
+        with self._executor_futures_lock:
+            for future in list(self._executor_futures):
+                future.cancel()
 
 
 # グローバルインスタンス

--- a/tests/systems/test_process_manager_shutdown.py
+++ b/tests/systems/test_process_manager_shutdown.py
@@ -1,0 +1,61 @@
+import os
+import threading
+
+import pytest
+
+from systems.process_manager import ProcessManager
+
+
+class DummyExecutor:
+    def __init__(self):
+        self.shutdown_calls = []
+
+    def shutdown(self, wait=True):
+        self.shutdown_calls.append(wait)
+
+
+class DummyProcessManager(ProcessManager):
+    def __init__(self, executor):
+        # 必要な属性のみ初期化し、副作用を避ける
+        self.processes = {}
+        self.monitoring_active = False
+        self.monitor_thread = None
+        self._shutdown_event = threading.Event()
+        self._shutdown_lock = threading.Lock()
+        self._shutdown_thread = None
+        self._executor = executor
+        self._resource_limit_lock = threading.Lock()
+        self._current_cpu_usage = 0.0
+        self._current_memory_usage = 0.0
+        self._max_system_cpu_percent = 80
+        self._max_system_memory_percent = 80
+        self._executor_futures = set()
+        self._executor_futures_lock = threading.Lock()
+
+    def stop_all_services(self, force=False):
+        self.stop_called = True
+        return True
+
+
+@pytest.mark.parametrize("force", [True, False])
+def test_graceful_shutdown_completes_without_type_error(monkeypatch, force):
+    executor = DummyExecutor()
+    manager = DummyProcessManager(executor)
+
+    exit_calls = []
+
+    def fake_exit(code):
+        exit_calls.append(code)
+        raise SystemExit(code)
+
+    monkeypatch.setattr(os, "_exit", fake_exit)
+
+    manager.stop_called = False
+
+    with pytest.raises(SystemExit) as excinfo:
+        manager._graceful_shutdown()
+
+    assert excinfo.value.code == 0
+    assert exit_calls == [0]
+    assert executor.shutdown_calls == [True]
+    assert manager.stop_called is True


### PR DESCRIPTION
## Summary
- add a regression unit test around ProcessManager._graceful_shutdown to guard against the prior ThreadPoolExecutor TypeError
- track submitted executor futures and implement timeout-aware graceful shutdown logic without passing unsupported timeout arguments
- refresh shutdown logging to describe the new bounded wait behaviour

## Testing
- pytest tests/systems -q

------
https://chatgpt.com/codex/tasks/task_e_68dc5bf86fcc8321a92303ba3ba52e41