### PR TITLE
Fix graceful shutdown executor call signature and add regression test

### DIFF
--- a/systems/process_manager.py
+++ b/systems/process_manager.py
@@ -579,8 +579,32 @@ class ProcessManager:
             
             # 並列実行プールのシャットダウン
             logger.info("並列実行プールをシャットダウン")
-            self._executor.shutdown(wait=True, timeout=10)
-            
+            shutdown_deadline = time.time() + 10
+            try:
+                self._executor.shutdown(wait=False)
+            except TypeError:
+                # 古いバージョンのconcurrent.futuresではwait引数のみサポート
+                logger.debug("wait=False をサポートしないためフォールバック")
+                self._executor.shutdown(wait=True)
+                shutdown_threads = []
+            else:
+                shutdown_threads = list(getattr(self._executor, "_threads", []))
+
+            # wait=False でシャットダウンした場合は明示的にタイムアウト監視
+            if shutdown_deadline is not None and shutdown_threads:
+                for thread in shutdown_threads:
+                    remaining = shutdown_deadline - time.time()
+                    if remaining <= 0:
+                        break
+                    thread.join(timeout=remaining)
+
+                if any(thread.is_alive() for thread in shutdown_threads):
+                    logger.warning(
+                        "並列実行プールのシャットダウンがタイムアウトしました"
+                    )
+                else:
+                    logger.info("並列実行プールのシャットダウン完了")
+
             logger.info("全サービス停止完了、プロセス終了")
             # シャットダウンイベントをクリア
             self._shutdown_event.clear()


### PR DESCRIPTION
## Summary
- add a regression test to ensure ProcessManager performs executor shutdown with supported arguments
- update graceful shutdown logic to drop the unsupported timeout keyword and monitor worker thread termination with a manual timeout

## Testing
- PYTHONPATH="/tmp:${PYTHONPATH}" pytest tests/unit/test_systems/test_process_manager.py::TestProcessManager::test_graceful_shutdown_uses_supported_executor_signature -q

------
https://chatgpt.com/codex/tasks/task_e_68dc5becf30c83218144f4be20cc1e41