### PR TITLE
Fix process manager monitoring restart

### DIFF
--- a/systems/process_manager.py
+++ b/systems/process_manager.py
@@ -353,6 +353,8 @@ class ProcessManager:
         if self.monitoring_active:
             return
 
+        # 以前の監視停止時にセットされたシャットダウンフラグをリセット
+        self._shutdown_event.clear()
         self.monitoring_active = True
         self.monitor_thread = threading.Thread(
             target=self._monitor_processes, daemon=True
@@ -371,6 +373,9 @@ class ProcessManager:
             if self.monitor_thread.is_alive():
                 logger.warning("監視スレッドの終了待機タイムアウト")
                 # デーモンスレッドなので強制終了は不要
+
+        # 再起動時の状態を明示的に初期化
+        self.monitor_thread = None
 
         logger.info("プロセス監視停止")
 

--- a/tests/systems/test_process_manager_monitoring.py
+++ b/tests/systems/test_process_manager_monitoring.py
@@ -1,0 +1,26 @@
+import time
+
+from systems.process_manager import ProcessManager
+
+
+def test_monitoring_can_restart_after_stop():
+    manager = ProcessManager()
+    try:
+        manager.start_monitoring()
+        time.sleep(0.1)
+
+        assert manager.monitor_thread is not None
+        assert manager.monitor_thread.is_alive()
+
+        manager.stop_monitoring()
+        assert manager._shutdown_event.is_set()
+
+        manager.start_monitoring()
+        time.sleep(0.1)
+
+        assert manager.monitor_thread is not None
+        assert manager.monitor_thread.is_alive()
+        assert not manager._shutdown_event.is_set()
+    finally:
+        manager.stop_monitoring()
+        manager.wait_for_shutdown()


### PR DESCRIPTION
## Summary
- add a regression test that verifies monitoring can restart after stop/start cycles
- clear the shutdown event and reset the monitor thread when restarting monitoring

## Testing
- python - <<'PY'
import sys
import types
from dataclasses import dataclass
from datetime import datetime, timedelta

pandas = types.ModuleType('pandas')


class DataFrame(dict):
    def __init__(self, data=None, index=None):
        super().__init__(data or {})
        self.index = index


class Series(list):
    pass


def date_range(start=None, end=None, periods=None, freq=None):
    if start is None or end is None:
        return []
    if not isinstance(start, datetime):
        start = datetime.combine(start, datetime.min.time())
    if not isinstance(end, datetime):
        end = datetime.combine(end, datetime.min.time())
    days = (end - start).days
    return [start + timedelta(days=i) for i in range(days + 1)]


pandas.DataFrame = DataFrame
pandas.Series = Series
pandas.date_range = date_range
sys.modules['pandas'] = pandas

numpy = types.ModuleType('numpy')


def array(values, *args, **kwargs):
    return list(values)


def ndarray(*args, **kwargs):
    return list(args[0]) if args else []


numpy.array = array
numpy.ndarray = ndarray
sys.modules['numpy'] = numpy

lightgbm = types.ModuleType('lightgbm')


class Booster:
    pass


lightgbm.Booster = Booster
sys.modules['lightgbm'] = lightgbm

joblib = types.ModuleType('joblib')


def dump(*args, **kwargs):
    return None


def load(*args, **kwargs):
    return None


joblib.dump = dump
joblib.load = load
sys.modules['joblib'] = joblib

psutil = types.ModuleType('psutil')


def cpu_percent(interval=None):
    return 0.0


def virtual_memory():
    return types.SimpleNamespace(percent=0.0, total=1024 * 1024 * 1024)


class _Process:
    def __init__(self, pid):
        self.pid = pid

    def memory_info(self):
        return types.SimpleNamespace(rss=0)

    def cpu_percent(self):
        return 0.0

    def terminate(self):
        pass


psutil.Process = _Process
psutil.NoSuchProcess = Exception
psutil.AccessDenied = Exception
psutil.cpu_percent = cpu_percent
psutil.virtual_memory = virtual_memory
sys.modules['psutil'] = psutil

models = types.ModuleType('models')
recommendation = types.ModuleType('models.recommendation')


@dataclass
class StockRecommendation:
    rank: int
    symbol: str
    company_name: str
    buy_timing: str
    target_price: float
    stop_loss: float
    profit_target_1: float
    profit_target_2: float
    holding_period: str
    score: float
    current_price: float
    recommendation_reason: str


recommendation.StockRecommendation = StockRecommendation
sys.modules['models'] = models
sys.modules['models.recommendation'] = recommendation
setattr(models, 'recommendation', recommendation)

import pytest
raise SystemExit(pytest.main(['tests/systems/test_process_manager_monitoring.py']))
PY

------
https://chatgpt.com/codex/tasks/task_e_68dc5bf0d5888321951b03a68da2ded9