### PR TITLE
Add pattern-based temp cleanup utility

### DIFF
--- a/tests/unit/test_temp_cleanup.py
+++ b/tests/unit/test_temp_cleanup.py
@@ -46,3 +46,22 @@ def test_cleanup_all_removes_directories_and_files(cleanup_manager, tmp_path):
     assert cleanup_manager.temp_dirs == []
     assert not temp_file.exists()
     assert not temp_dir.exists()
+
+
+def test_cleanup_by_pattern_removes_unwanted_paths(cleanup_manager, tmp_path):
+    obsolete_file = tmp_path / "obsolete_file.log"
+    obsolete_file.write_text("log")
+
+    obsolete_dir = tmp_path / "obsolete_dir"
+    obsolete_dir.mkdir()
+    (obsolete_dir / "nested.txt").write_text("nested")
+
+    keep_file = tmp_path / "keep.log"
+    keep_file.write_text("keep")
+
+    removed_count = cleanup_manager.cleanup_by_pattern(str(tmp_path / "obsolete_*"))
+
+    assert removed_count == 2
+    assert not obsolete_file.exists()
+    assert not obsolete_dir.exists()
+    assert keep_file.exists()

--- a/utils/temp_cleanup.py
+++ b/utils/temp_cleanup.py
@@ -130,6 +130,35 @@ class TempFileCleanup:
             logger.error(f"Error during old files cleanup: {e}")
 
 
+    def cleanup_by_pattern(self, pattern: str) -> int:
+        """Remove files or directories that match the provided glob pattern."""
+
+        removed_count = 0
+        paths = glob.glob(pattern)
+
+        for path in paths:
+            try:
+                if os.path.isdir(path) and not os.path.islink(path):
+                    shutil.rmtree(path)
+                else:
+                    os.remove(path)
+                removed_count += 1
+                logger.debug(f"Removed path via pattern cleanup: {path}")
+            except FileNotFoundError:
+                logger.debug(f"Path already removed before pattern cleanup: {path}")
+            except Exception as exc:
+                logger.warning(f"Failed to remove path {path} during pattern cleanup: {exc}")
+
+        if removed_count > 0:
+            logger.info(
+                "Removed %d items matching pattern '%s' during temp cleanup",
+                removed_count,
+                pattern,
+            )
+
+        return removed_count
+
+
 # Global instance
 temp_cleanup = TempFileCleanup()
 


### PR DESCRIPTION
## Summary
- add a unit test that verifies temp cleanup removes files and directories matched by a glob pattern
- extend TempFileCleanup with cleanup_by_pattern to delete unwanted files or directories and report how many were removed

## Testing
- pytest tests/unit/test_temp_cleanup.py

------
https://chatgpt.com/codex/tasks/task_e_68dc6fd1099083219596ca9017a2bb82