### PR TITLE
Add utility to remove unnecessary temporary files

### DIFF
--- a/tests/unit/test_temp_cleanup.py
+++ b/tests/unit/test_temp_cleanup.py
@@ -46,3 +46,35 @@ def test_cleanup_all_removes_directories_and_files(cleanup_manager, tmp_path):
     assert cleanup_manager.temp_dirs == []
     assert not temp_file.exists()
     assert not temp_dir.exists()
+
+
+def test_cleanup_unnecessary_files_removes_non_whitelisted(cleanup_manager, tmp_path):
+    base_dir = tmp_path / "artifacts"
+    base_dir.mkdir()
+
+    keep_file = base_dir / "keep.txt"
+    keep_file.write_text("keep")
+    extra_file = base_dir / "remove.log"
+    extra_file.write_text("remove")
+    nested_dir = base_dir / "subdir"
+    nested_dir.mkdir()
+    (nested_dir / "nested.txt").write_text("nested")
+
+    removed = cleanup_manager.cleanup_unnecessary_files(
+        str(base_dir), required_entries={"keep.txt", "subdir"}
+    )
+
+    assert removed == [str(extra_file)]
+    assert keep_file.exists()
+    assert not extra_file.exists()
+    assert nested_dir.exists()
+
+
+def test_cleanup_unnecessary_files_handles_missing_directory(cleanup_manager, tmp_path):
+    missing_dir = tmp_path / "does_not_exist"
+
+    removed = cleanup_manager.cleanup_unnecessary_files(
+        str(missing_dir), required_entries={"keep.txt"}
+    )
+
+    assert removed == []

--- a/utils/temp_cleanup.py
+++ b/utils/temp_cleanup.py
@@ -2,12 +2,12 @@
 Temporary file cleanup utilities
 """
 
-import os
-import tempfile
 import glob
 import logging
+import os
 import shutil
-from typing import Callable, List
+import tempfile
+from typing import Callable, Iterable, List, Set
 from utils.logger_config import get_logger
 from utils.context_managers import get_shutdown_manager
 
@@ -128,6 +128,42 @@ class TempFileCleanup:
 
         except Exception as e:
             logger.error(f"Error during old files cleanup: {e}")
+
+    def cleanup_unnecessary_files(
+        self, base_dir: str, required_entries: Iterable[str]
+    ) -> List[str]:
+        """Remove files or directories in base_dir that are not required."""
+        if not os.path.isdir(base_dir):
+            logger.debug(
+                "Skipped cleanup for non-existent directory: %s", base_dir
+            )
+            return []
+
+        required_set: Set[str] = set(required_entries)
+        removed: List[str] = []
+
+        for entry in os.listdir(base_dir):
+            if entry in required_set:
+                continue
+
+            full_path = os.path.join(base_dir, entry)
+
+            if os.path.isdir(full_path):
+                if self.cleanup_dir(full_path):
+                    removed.append(full_path)
+            else:
+                if self.cleanup_file(full_path):
+                    removed.append(full_path)
+
+        removed.sort()
+        if removed:
+            logger.info(
+                "Removed %d unnecessary entries from %s", len(removed), base_dir
+            )
+        else:
+            logger.debug("No unnecessary entries found in %s", base_dir)
+
+        return removed
 
 
 # Global instance


### PR DESCRIPTION
## Summary
- add unit tests covering removal of non-whitelisted temporary entries
- implement `cleanup_unnecessary_files` on `TempFileCleanup` to delete files and directories not required

## Testing
- pytest tests/unit/test_temp_cleanup.py

------
https://chatgpt.com/codex/tasks/task_e_68dc6fd1099083219596ca9017a2bb82