### PR TITLE
Avoid logging side effects when importing models.core

### DIFF
--- a/models/core.py
+++ b/models/core.py
@@ -9,9 +9,6 @@ from typing import Any, Dict, Iterable, List, Optional, Callable, ClassVar
 import logging
 
 import hashlib
-from utils.logger import setup_logging # 修正
-
-setup_logging() # 追加
 logger = logging.getLogger(__name__) # 修正
 
 import json

--- a/tests/unit/test_models/test_core_logging.py
+++ b/tests/unit/test_models/test_core_logging.py
@@ -1,0 +1,19 @@
+"""Regression tests covering logging side effects in models.core."""
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_core_reload_does_not_trigger_setup_logging(monkeypatch):
+    """Reloading models.core should not mutate logging via setup_logging."""
+    import models.core as core
+
+    def _fail(*args, **kwargs):
+        raise RuntimeError("setup_logging should not be called during models.core import")
+
+    monkeypatch.setattr("utils.logger.setup_logging", _fail)
+
+    # If models.core calls setup_logging during import, this will raise and fail the test.
+    importlib.reload(core)


### PR DESCRIPTION
## Summary
- add a regression test to ensure reloading `models.core` does not invoke `utils.logger.setup_logging`
- stop calling `setup_logging` from `models.core` so importing the module no longer mutates global logging

## Testing
- pytest tests/unit/test_models/test_core_logging.py


------
https://chatgpt.com/codex/tasks/task_e_68dcaadc2924832183a865d48473a0a0