### PR TITLE
Expand recommendations top_n limit to 50

### DIFF
--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -27,16 +27,12 @@ router = APIRouter()
 
 @router.get("/recommendations", response_model=RecommendationResponse)
 async def get_recommendations(
-    top_n: int = Query(5, ge=1, le=10, description="推奨銘柄の上位N件を取得"),
+    top_n: int = Query(5, ge=1, le=50, description="推奨銘柄の上位N件を取得"),
     credentials: HTTPAuthorizationCredentials = Depends(security),
 ):
     try:
         # Authentication verification
         verify_token(credentials.credentials)
-
-        # Input validation
-        if not (1 <= top_n <= 50):  # Stricter limit for security
-            raise ValidationError("top_n must be between 1 and 50")
 
         predictor = MLStockPredictor()
         recommendations = predictor.get_top_recommendations(top_n)

--- a/tests/unit/test_app/test_api.py
+++ b/tests/unit/test_app/test_api.py
@@ -134,7 +134,7 @@ class TestAPI:
         """無効なパラメータでの推奨銘柄エンドポイントテスト"""
         # top_nが範囲外
         response = client.get(
-            "/api/v1/recommendations?top_n=15", headers=AUTH_HEADER
+            "/api/v1/recommendations?top_n=51", headers=AUTH_HEADER
         )
         assert response.status_code == 422  # Validation Error
 


### PR DESCRIPTION
## Summary
- raise the recommendations endpoint validation limit to allow up to 50 results directly through FastAPI's Query constraint
- add regression coverage for accepting top_n=50 and rejecting out-of-range requests, including environment setup for standalone endpoint tests
- update API tests to reflect the expanded limit

## Testing
- pytest tests/test_api_endpoints.py
- CLSTOCK_DEV_KEY=dev-key CLSTOCK_ADMIN_KEY=admin-key pytest tests/unit/test_app/test_api.py::TestAPI::test_get_recommendations_invalid_params

------
https://chatgpt.com/codex/tasks/task_e_68dcaadc8c3c8321b477e497b0276f2b