### PR TITLE
Add datetime reuse in recommendations and test

### DIFF
--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -41,12 +41,14 @@ async def get_recommendations(
         predictor = MLStockPredictor()
         recommendations = predictor.get_top_recommendations(top_n)
 
+        current_time = datetime.now()
+
         return RecommendationResponse(
             recommendations=recommendations,
-            generated_at=datetime.now(),
+            generated_at=current_time,
             market_status=(
                 "市場営業時間外"
-                if datetime.now().hour < 9 or datetime.now().hour > 15
+                if current_time.hour < 9 or current_time.hour > 15
                 else "市場営業中"
             ),
         )


### PR DESCRIPTION
## Summary
- add regression test ensuring the recommendations endpoint only calls datetime.now once
- update the endpoint to reuse a cached datetime value for response metadata and market status

## Testing
- pytest tests/test_api_endpoints.py -k recommendations *(fails: missing numpy dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcaadcdab88321b5a3886551e1cda3