### PR TITLE
Refactor settings initialization for lazy loading

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -2,6 +2,12 @@
 設定管理パッケージ
 """
 
-from .settings import settings, get_settings, AppSettings
+from .settings import AppSettings, create_settings, get_settings, load_from_env, load_settings
 
-__all__ = ["settings", "get_settings", "AppSettings"]
+__all__ = [
+    "AppSettings",
+    "create_settings",
+    "get_settings",
+    "load_from_env",
+    "load_settings",
+]

--- a/systems/process_manager.py
+++ b/systems/process_manager.py
@@ -27,9 +27,6 @@ from utils.logger_config import get_logger
 from config.settings import get_settings
 
 logger = get_logger(__name__)
-settings = get_settings()
-
-
 class ProcessStatus(Enum):
     """プロセス状態"""
 
@@ -203,8 +200,9 @@ class ProcessManager:
             env = os.environ.copy()
             env.update(process_info.env_vars)
 
+            process_settings = get_settings().process
             capture_output = bool(
-                getattr(settings.process, "log_process_output", False)
+                getattr(process_settings, "log_process_output", False)
             )
 
             popen_kwargs = {
@@ -501,7 +499,7 @@ class ProcessManager:
                 
                 for proc_info in normal_priority_processes:
                     # 制限を元の設定に戻す
-                    original_settings = settings.process  # 設定から元の値を取得
+                    original_settings = get_settings().process  # 設定から元の値を取得
                     proc_info.max_cpu_percent = original_settings.max_cpu_percent_per_process if hasattr(original_settings, 'max_cpu_percent_per_process') else 50
                     proc_info.max_memory_mb = original_settings.max_memory_per_process_mb if hasattr(original_settings, 'max_memory_per_process_mb') else 1000
                     

--- a/tests/config/test_settings_factory.py
+++ b/tests/config/test_settings_factory.py
@@ -1,0 +1,17 @@
+import importlib
+import sys
+
+
+def test_settings_lazy_loading(monkeypatch):
+    monkeypatch.setenv("CLSTOCK_API_TITLE", "FromEnv")
+    # Ensure we import a fresh module instance
+    sys.modules.pop("config.settings", None)
+
+    settings_module = importlib.import_module("config.settings")
+
+    # The module should not eagerly create a settings singleton on import
+    assert getattr(settings_module, "_SETTINGS_SINGLETON", None) is None
+
+    # Explicitly creating settings should apply environment overrides
+    created = settings_module.create_settings()
+    assert created.api.title == "FromEnv"

--- a/tests/unit/test_config/test_settings.py
+++ b/tests/unit/test_config/test_settings.py
@@ -1,10 +1,9 @@
 """Tests for the configuration system."""
 
 import os
-import pytest
 from unittest.mock import patch
 
-from config.settings import AppSettings, load_from_env, get_settings
+from config.settings import AppSettings, create_settings, get_settings
 
 
 class TestConfiguration:
@@ -53,27 +52,9 @@ class TestConfiguration:
     )
     def test_environment_variable_loading(self):
         """Test loading configuration from environment variables."""
-        # Reset settings to test environment variable loading
-        settings = get_settings()
+        settings = create_settings()
 
-        # Store original values
-        original_api_title = settings.api.title
-        original_log_level = settings.logging.level
-        original_initial_capital = settings.backtest.default_initial_capital
-        original_score_threshold = settings.backtest.default_score_threshold
-
-        try:
-            # Load from environment
-            load_from_env()
-
-            # Check that values were updated
-            assert settings.api.title == "Test API"
-            assert settings.logging.level == "DEBUG"
-            assert settings.backtest.default_initial_capital == 2000000
-            assert settings.backtest.default_score_threshold == 75
-        finally:
-            # Restore original values
-            settings.api.title = original_api_title
-            settings.logging.level = original_log_level
-            settings.backtest.default_initial_capital = original_initial_capital
-            settings.backtest.default_score_threshold = original_score_threshold
+        assert settings.api.title == "Test API"
+        assert settings.logging.level == "DEBUG"
+        assert settings.backtest.default_initial_capital == 2000000
+        assert settings.backtest.default_score_threshold == 75


### PR DESCRIPTION
## Summary
- refactor the settings module to expose pure `load_settings`/`create_settings` helpers and lazily instantiate the singleton
- update process manager and configuration tests to work with the deferred settings initialization and realistic defaults
- add a regression test ensuring environment overrides are only applied when explicitly creating settings

## Testing
- pytest tests/config/test_settings_factory.py
- pytest tests/unit/test_config

------
https://chatgpt.com/codex/tasks/task_e_68dcac7431a08321a33ca559cfafc4f7