### PR TITLE
Refactor ProcessManager imports to avoid sys.path mutation

### DIFF
--- a/ClStock/__init__.py
+++ b/ClStock/__init__.py
@@ -1,0 +1,18 @@
+"""Top-level package for the ClStock project."""
+from __future__ import annotations
+
+from pathlib import Path
+
+# The project is structured with most modules living directly under the
+# repository root. By exposing the repository root as a package search path
+# we can import modules such as ``ClStock.systems.process_manager`` without
+# mutating ``sys.path`` during runtime initialisation.
+_package_dir = Path(__file__).resolve().parent
+_project_root = _package_dir.parent
+
+# ``__path__`` defines where Python looks for submodules of ``ClStock``.
+# We include both the package directory itself (to allow future package-local
+# modules) and the repository root where the existing modules reside.
+__path__ = [str(_package_dir), str(_project_root)]
+
+__all__ = []

--- a/clstock_cli.py
+++ b/clstock_cli.py
@@ -13,11 +13,10 @@ from typing import Optional
 
 # プロジェクトルート設定
 PROJECT_ROOT = Path(__file__).parent
-sys.path.append(str(PROJECT_ROOT))
 
-from systems.process_manager import get_process_manager, ProcessStatus
-from utils.logger_config import get_logger
-from config.settings import get_settings
+from ClStock.systems.process_manager import get_process_manager, ProcessStatus
+from ClStock.utils.logger_config import get_logger
+from ClStock.config.settings import get_settings
 
 logger = get_logger(__name__)
 settings = get_settings()

--- a/systems/__init__.py
+++ b/systems/__init__.py
@@ -1,0 +1,1 @@
+"""Systems package for ClStock."""

--- a/systems/process_manager.py
+++ b/systems/process_manager.py
@@ -4,7 +4,6 @@ ClStock プロセス管理システム
 """
 
 import os
-import sys
 import psutil
 import subprocess
 import threading
@@ -21,10 +20,9 @@ from enum import Enum
 
 # プロジェクトルート設定
 PROJECT_ROOT = Path(__file__).parent.parent
-sys.path.append(str(PROJECT_ROOT))
 
-from utils.logger_config import get_logger
-from config.settings import get_settings
+from ClStock.utils.logger_config import get_logger
+from ClStock.config.settings import get_settings
 
 logger = get_logger(__name__)
 settings = get_settings()

--- a/tests/systems/test_process_manager_monitoring.py
+++ b/tests/systems/test_process_manager_monitoring.py
@@ -1,6 +1,6 @@
 import time
 
-from systems.process_manager import ProcessManager
+from ClStock.systems.process_manager import ProcessManager
 
 
 def test_monitoring_can_restart_after_stop():

--- a/tests/systems/test_process_manager_shutdown.py
+++ b/tests/systems/test_process_manager_shutdown.py
@@ -3,7 +3,7 @@ import threading
 
 import pytest
 
-from systems.process_manager import ProcessManager
+from ClStock.systems.process_manager import ProcessManager
 
 
 class DummyExecutor:

--- a/tests/unit/test_cli_comprehensive.py
+++ b/tests/unit/test_cli_comprehensive.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner
 from datetime import datetime
 
 from clstock_cli import cli
-from systems.process_manager import ProcessInfo, ProcessStatus
+from ClStock.systems.process_manager import ProcessInfo, ProcessStatus
 
 
 class TestClStockCLI:

--- a/tests/unit/test_imports_no_sys_path_mutation.py
+++ b/tests/unit/test_imports_no_sys_path_mutation.py
@@ -1,0 +1,49 @@
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    ["clstock_cli", "ClStock.systems.process_manager"],
+)
+def test_import_does_not_modify_sys_path(monkeypatch, module_name):
+    original_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == module_name or name.startswith(f"{module_name}.")
+    }
+    if module_name.startswith("ClStock."):
+        clstock_modules = {
+            name: module
+            for name, module in sys.modules.items()
+            if name == "ClStock" or name.startswith("ClStock.")
+        }
+        original_modules.update(clstock_modules)
+    for name in original_modules:
+        sys.modules.pop(name, None)
+
+    class GuardedPath(list):
+        def append(self, item):
+            raise AssertionError(
+                f"sys.path.append was called with {item!r} during import of {module_name}"
+            )
+
+        def extend(self, items):
+            raise AssertionError(
+                f"sys.path.extend was called with {items!r} during import of {module_name}"
+            )
+
+        def insert(self, index, item):
+            raise AssertionError(
+                f"sys.path.insert was called with {item!r} during import of {module_name}"
+            )
+
+    guarded_path = GuardedPath(sys.path)
+    monkeypatch.setattr(sys, "path", guarded_path)
+
+    try:
+        importlib.import_module(module_name)
+    finally:
+        sys.modules.update(original_modules)

--- a/tests/unit/test_systems/conftest.py
+++ b/tests/unit/test_systems/conftest.py
@@ -7,6 +7,6 @@ from unittest.mock import Mock
 @pytest.fixture
 def mock_process_manager():
     """Mock process manager fixture."""
-    from systems.process_manager import ProcessManager
+    from ClStock.systems.process_manager import ProcessManager
 
     return ProcessManager()

--- a/tests/unit/test_systems/test_process_manager.py
+++ b/tests/unit/test_systems/test_process_manager.py
@@ -5,7 +5,7 @@ import threading
 from unittest.mock import Mock, patch, MagicMock
 from datetime import datetime
 
-from systems.process_manager import (
+from ClStock.systems.process_manager import (
     ProcessManager,
     ProcessInfo,
     ProcessStatus,
@@ -66,7 +66,7 @@ class TestProcessManager:
         assert process_info.restart_count == 0
         assert process_info.pid is None
 
-    @patch("systems.process_manager.subprocess.Popen")
+    @patch("ClStock.systems.process_manager.subprocess.Popen")
     def test_start_service_success(self, mock_popen):
         """Test successful service start."""
         # Mock the subprocess
@@ -85,7 +85,7 @@ class TestProcessManager:
         assert pm.processes["dashboard"].pid == 12345
         mock_popen.assert_called_once()
 
-    @patch("systems.process_manager.subprocess.Popen")
+    @patch("ClStock.systems.process_manager.subprocess.Popen")
     def test_start_service_already_running(self, mock_popen):
         """Test starting a service that's already running."""
         mock_process = Mock()
@@ -104,7 +104,7 @@ class TestProcessManager:
         assert result is True
         mock_popen.assert_called_once()  # Only called once
 
-    @patch("systems.process_manager.subprocess.Popen")
+    @patch("ClStock.systems.process_manager.subprocess.Popen")
     def test_start_service_inherits_streams_when_logging_disabled(
         self, mock_popen
     ):
@@ -128,7 +128,7 @@ class TestProcessManager:
         assert kwargs.get("stdout") is None
         assert kwargs.get("stderr") is None
 
-    @patch("systems.process_manager.subprocess.Popen")
+    @patch("ClStock.systems.process_manager.subprocess.Popen")
     def test_start_service_file_not_found(self, mock_popen):
         """Test service start failure due to file not found."""
         mock_popen.side_effect = FileNotFoundError("python not found")
@@ -153,7 +153,7 @@ class TestProcessManager:
         # Should return True (no error)
         assert result is True
 
-    @patch("systems.process_manager.subprocess.Popen")
+    @patch("ClStock.systems.process_manager.subprocess.Popen")
     def test_get_service_status(self, mock_popen):
         """Test getting service status."""
         mock_process = Mock()
@@ -200,7 +200,7 @@ class TestProcessManager:
         assert "test_service" in pm.processes
         assert pm.processes["test_service"] is service_info
 
-    @patch("systems.process_manager.subprocess.Popen")
+    @patch("ClStock.systems.process_manager.subprocess.Popen")
     def test_start_service_with_quoted_arguments(self, mock_popen):
         """Service commands with quoted arguments should be parsed correctly."""
         pm = ProcessManager()
@@ -220,7 +220,7 @@ class TestProcessManager:
         args, _ = mock_popen.call_args
         assert args[0] == ["python", "-c", "print('hello world')"]
 
-    @patch("systems.process_manager.psutil")
+    @patch("ClStock.systems.process_manager.psutil")
     def test_get_system_status(self, mock_psutil):
         """Test getting system resource information."""
         # Mock psutil responses
@@ -271,7 +271,7 @@ class TestProcessManager:
 
         pm._shutdown_event.set()
 
-        with patch("systems.process_manager.os._exit") as mock_exit:
+        with patch("ClStock.systems.process_manager.os._exit") as mock_exit:
             pm._graceful_shutdown()
 
         pm.stop_all_services.assert_called_once_with(force=True)

--- a/tests/unit/test_systems/test_process_manager_comprehensive.py
+++ b/tests/unit/test_systems/test_process_manager_comprehensive.py
@@ -6,7 +6,7 @@ import time
 from unittest.mock import Mock, patch, MagicMock
 from datetime import datetime
 
-from systems.process_manager import (
+from ClStock.systems.process_manager import (
     ProcessManager,
     ProcessInfo,
     ProcessStatus,
@@ -78,7 +78,7 @@ class TestProcessManagerComprehensive:
         assert process_info.restart_count == 0
         assert process_info.last_error is None
 
-    @patch("systems.process_manager.subprocess.Popen")
+    @patch("ClStock.systems.process_manager.subprocess.Popen")
     def test_service_lifecycle_complete(self, mock_popen):
         """Test complete service lifecycle: register, start, stop, restart."""
         mock_process = Mock()
@@ -107,7 +107,7 @@ class TestProcessManagerComprehensive:
         assert pm.restart_service("lifecycle_test") is True
         assert pm.processes["lifecycle_test"].status == ProcessStatus.RUNNING
 
-    @patch("systems.process_manager.subprocess.Popen")
+    @patch("ClStock.systems.process_manager.subprocess.Popen")
     def test_start_service_various_failure_scenarios(self, mock_popen):
         """Test service start with various failure scenarios."""
         pm = ProcessManager()
@@ -133,7 +133,7 @@ class TestProcessManagerComprehensive:
         assert pm.processes["investment_system"].status == ProcessStatus.FAILED
         assert pm.processes["investment_system"].last_error == "generic error"
 
-    @patch("systems.process_manager.subprocess.Popen")
+    @patch("ClStock.systems.process_manager.subprocess.Popen")
     def test_stop_service_scenarios(self, mock_popen):
         """Test various service stop scenarios."""
         mock_process = Mock()
@@ -157,7 +157,7 @@ class TestProcessManagerComprehensive:
         assert result is True
         assert pm.processes["dashboard"].status == ProcessStatus.STOPPED
 
-    @patch("systems.process_manager.subprocess.Popen")
+    @patch("ClStock.systems.process_manager.subprocess.Popen")
     def test_stop_service_with_force(self, mock_popen):
         """Test force stopping a service."""
         mock_process = Mock()
@@ -203,7 +203,7 @@ class TestProcessManagerComprehensive:
         assert "monitoring_active" in system_status
         assert system_status["total_services"] == len(pm.processes)
 
-    @patch("systems.process_manager.subprocess.Popen")
+    @patch("ClStock.systems.process_manager.subprocess.Popen")
     def test_auto_restart_functionality(self, mock_popen):
         """Test auto-restart functionality."""
         mock_process = Mock()
@@ -229,8 +229,8 @@ class TestProcessManagerComprehensive:
         assert pm.processes["restart_test"].status == ProcessStatus.RUNNING
         assert pm.processes["restart_test"].restart_count == 0
 
-    @patch("systems.process_manager.subprocess.Popen")
-    @patch("systems.process_manager.psutil.Process")
+    @patch("ClStock.systems.process_manager.subprocess.Popen")
+    @patch("ClStock.systems.process_manager.psutil.Process")
     def test_process_health_check(self, mock_psutil_process, mock_popen):
         """Test process health check functionality."""
         mock_process = Mock()
@@ -253,7 +253,7 @@ class TestProcessManagerComprehensive:
         # Process should still be running
         assert pm.processes["dashboard"].status == ProcessStatus.RUNNING
 
-    @patch("systems.process_manager.subprocess.Popen")
+    @patch("ClStock.systems.process_manager.subprocess.Popen")
     def test_stop_all_services(self, mock_popen):
         """Test stopping all services."""
         mock_process = Mock()
@@ -291,7 +291,7 @@ class TestProcessManagerComprehensive:
         assert pm.register_service(service2) is True
         assert pm.processes["test_service"].command == "python test2.py"
 
-    @patch("systems.process_manager.subprocess.Popen")
+    @patch("ClStock.systems.process_manager.subprocess.Popen")
     def test_concurrent_service_operations(self, mock_popen):
         """Test concurrent service operations."""
         mock_process = Mock()


### PR DESCRIPTION
## Summary
- add a top-level `ClStock` package that exposes the repository root so modules can be resolved without modifying `sys.path`
- switch the CLI and process manager modules (and their tests) to use absolute imports based on the new package
- add a regression test that ensures importing the CLI and process manager does not write to `sys.path`

## Testing
- `pytest tests/unit/test_imports_no_sys_path_mutation.py`
- `CLSTOCK_DEV_KEY=test CLSTOCK_ADMIN_KEY=test CLSTOCK_PROD_KEY=test pytest` *(fails due to numerous pre-existing test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68dcaa35b59c83219631f81be1c8cc88