### PR TITLE
Remove sys.path mutation from process manager imports

### DIFF
--- a/systems/process_manager.py
+++ b/systems/process_manager.py
@@ -12,13 +12,7 @@ import threading # Added for start_service
 import time # Added for start_service
 from enum import Enum # Added for start_service
 from dataclasses import dataclass, field # Added for start_service
-from pathlib import Path # Added for start_service
 from typing import Union, Sequence # Added for start_service
-
-# プロジェクトルート設定
-PROJECT_ROOT = Path(__file__).parent.parent
-import sys # Added for start_service
-sys.path.append(str(PROJECT_ROOT))
 
 from utils.logger_config import get_logger
 from config.settings import get_settings


### PR DESCRIPTION
## Summary
- remove the manual sys.path mutation from `systems.process_manager`

## Testing
- pytest tests/unit/test_imports_no_sys_path_mutation.py::test_import_does_not_modify_sys_path

------
https://chatgpt.com/codex/tasks/task_e_68dd0e47f2988321bde0fd12282568e8