### PR TITLE
Update spec CLI client command

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -62,7 +62,7 @@
 ## 5. システム構成
 ### 第1段階（CUI + API）
 - **バックエンド**: Python (FastAPI)
-- **CUIクライアント**: `python recommend.py --top 5`
+- **CUIクライアント**: `python clstock_cli.py`（例: `python clstock_cli.py system predict -s 7203`）
 - **出力形式**: JSON + テキスト
 
 ### 第2段階（GUI）


### PR DESCRIPTION
## Summary
- replace the outdated CLI command in the specification with the current `clstock_cli.py` entry point
- provide an example subcommand to match the README usage instructions

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dd26d3eb708321952d3f12e55e19e5