### PR TITLE
Align recommendation default count with Top 10 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ API_KEYS = {
 
 #### API エンドポイント
 
-- `GET /recommendations?top_n=5` - 推奨銘柄ランキング（認証必要）
+- `GET /recommendations?top_n=10` - 推奨銘柄ランキング（認証必要）
 - `GET /recommendation/{symbol}` - 特定銘柄の推奨（認証必要）
 - `GET /stocks` - 利用可能な銘柄一覧
 - `GET /stock/{symbol}/data` - 株価データと技術指標

--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -27,7 +27,7 @@ router = APIRouter()
 
 @router.get("/recommendations", response_model=RecommendationResponse)
 async def get_recommendations(
-    top_n: int = Query(5, ge=1, le=50, description="推奨銘柄の上位N件を取得"),
+    top_n: int = Query(10, ge=1, le=50, description="推奨銘柄の上位N件を取得"),
     credentials: HTTPAuthorizationCredentials = Depends(security),
 ):
     try:

--- a/models/core.py
+++ b/models/core.py
@@ -631,7 +631,7 @@ class MLStockPredictor(CacheablePredictor):
 
         return recommendation
 
-    def get_top_recommendations(self, top_n: int = 5) -> List[StockRecommendation]:
+    def get_top_recommendations(self, top_n: int = 10) -> List[StockRecommendation]:
         symbols = self.data_provider.get_all_stock_symbols()
         recommendations: List[StockRecommendation] = []
 

--- a/spec.md
+++ b/spec.md
@@ -62,7 +62,7 @@
 ## 5. システム構成
 ### 第1段階（CUI + API）
 - **バックエンド**: Python (FastAPI)
-- **CUIクライアント**: `python recommend.py --top 5`
+- **CUIクライアント**: `python recommend.py --top 10`
 - **出力形式**: JSON + テキスト
 
 ### 第2段階（GUI）

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -128,10 +128,15 @@ def test_get_recommendations_returns_closed_after_15(monkeypatch):
     monkeypatch.setattr("api.endpoints.datetime", DummyDateTime)
 
     class DummyPredictor:
+        def __init__(self) -> None:
+            self.received_top_n = None
+
         def get_top_recommendations(self, top_n):
+            self.received_top_n = top_n
             return []
 
-    monkeypatch.setattr("api.endpoints.MLStockPredictor", lambda: DummyPredictor())
+    dummy_predictor = DummyPredictor()
+    monkeypatch.setattr("api.endpoints.MLStockPredictor", lambda: dummy_predictor)
     monkeypatch.setattr("api.endpoints.verify_token", lambda token: None)
 
     response = client.get(
@@ -140,6 +145,7 @@ def test_get_recommendations_returns_closed_after_15(monkeypatch):
     )
 
     assert response.status_code == 200
+    assert dummy_predictor.received_top_n == 10
     assert response.json()["market_status"] == "市場営業時間外"
 
 

--- a/tests/unit/test_app/test_api.py
+++ b/tests/unit/test_app/test_api.py
@@ -251,6 +251,7 @@ class TestAPI:
             )
             assert response.status_code == 500
             assert "推奨銘柄の取得に失敗しました" in response.json()["detail"]
+            mock_predictor.get_top_recommendations.assert_called_once_with(10)
 
     @pytest.mark.api
     def test_market_status_logic(self, client, sample_recommendation):


### PR DESCRIPTION
## Summary
- increase the MLStockPredictor default recommendation count to 10 and align the API endpoint default
- update tests to enforce the new Top 10 expectation and document the change in the spec and README

## Testing
- CLSTOCK_DEV_KEY=development-key CLSTOCK_ADMIN_KEY=admin-key pytest tests/unit/test_app/test_api.py -k test_api_error_handling
- CLSTOCK_DEV_KEY=development-key CLSTOCK_ADMIN_KEY=admin-key pytest tests/test_api_endpoints.py::test_get_recommendations_returns_closed_after_15

------
https://chatgpt.com/codex/tasks/task_e_68dd26d85bcc8321a1a6b2014cc1136e