### PR TITLE
Update CUI client command in spec

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -62,7 +62,9 @@
 ## 5. システム構成
 ### 第1段階（CUI + API）
 - **バックエンド**: Python (FastAPI)
-- **CUIクライアント**: `python recommend.py --top 5`
+- **CUIクライアント**: `python investment_advisor_cui.py --top 5`
+  - 実行ディレクトリ: リポジトリルート（`ClStock/`）
+  - 前提条件: `pip install -r requirements.txt` などで依存関係（特に NumPy などの科学計算ライブラリ）を事前にインストールしておく
 - **出力形式**: JSON + テキスト
 
 ### 第2段階（GUI）


### PR DESCRIPTION
## Summary
- update the stage 1 CUI command in the spec to reference the current entry point
- add usage notes about the working directory and dependency installation required for the CLI

## Testing
- `python investment_advisor_cui.py --top 1` *(fails: ImportError: Install numpy before running ClStock.)*


------
https://chatgpt.com/codex/tasks/task_e_68dd26e3a188832192d8c2d3cd07adff