### PR TITLE
Ensure financial metrics mirror requested symbol

### DIFF
--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -72,13 +72,20 @@ def test_get_stock_data_accepts_suffix_symbols(mock_provider_cls):
 
     mock_provider.get_stock_data.return_value = suffix_df
     mock_provider.calculate_technical_indicators.return_value = suffix_df
-    mock_provider.get_financial_metrics.return_value = {}
+    mock_provider.get_financial_metrics.return_value = {
+        "symbol": "7203",
+        "company_name": "Test Corp",
+        "actual_ticker": "7203",
+    }
 
     mock_provider_cls.return_value = mock_provider
 
     response = client.get("/stock/7203.T/data?period=1mo")
 
     assert response.status_code == 200
+    payload = response.json()
+    assert payload["financial_metrics"]["symbol"] == "7203.T"
+    assert payload["financial_metrics"]["actual_ticker"] == "7203"
 
 
 @patch("api.endpoints.StockDataProvider")


### PR DESCRIPTION
## Summary
- ensure `/stock/{symbol}/data` clones financial metrics, rewrites the symbol to the validated request, and preserves the resolved ticker
- extend the suffix ticker test to verify the nested financial metrics symbol reflects the requested code

## Testing
- `pytest tests/test_api_endpoints.py`


------
https://chatgpt.com/codex/tasks/task_e_68dd2864af448321a70480a055aa099a