### PR TITLE
Ensure recommendations use Tokyo timezone

### DIFF
--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException, Query, Depends
 from fastapi.security import HTTPAuthorizationCredentials
 
 from datetime import datetime, time
+from zoneinfo import ZoneInfo
 from dataclasses import dataclass
 from typing import List
 import pandas as pd
@@ -37,7 +38,7 @@ async def get_recommendations(
         predictor = MLStockPredictor()
         recommendations = predictor.get_top_recommendations(top_n)
 
-        current_time = datetime.now()
+        current_time = datetime.now(ZoneInfo("Asia/Tokyo"))
         market_open_time = time(9, 0)
         market_close_time = time(15, 0)
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,6 +1,7 @@
 import os
 import pandas as pd
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -123,7 +124,8 @@ def test_get_recommendations_returns_closed_after_15(monkeypatch):
     class DummyDateTime:
         @classmethod
         def now(cls, tz=None):
-            return datetime(2024, 1, 1, 15, 0, 0)
+            assert tz == ZoneInfo("Asia/Tokyo")
+            return datetime(2024, 1, 1, 15, 0, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
 
     monkeypatch.setattr("api.endpoints.datetime", DummyDateTime)
 


### PR DESCRIPTION
## Summary
- update the recommendations endpoint to compute the current time in the Tokyo timezone
- adjust the recommendation endpoint test to monkeypatch a timezone-aware datetime

## Testing
- pytest tests/test_api_endpoints.py::test_get_recommendations_returns_closed_after_15 *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68dd286572848321bfccefe456d4d17e