### PR TITLE
docs: document API JSON responses

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -65,6 +65,107 @@
 - **CUIクライアント**: `python recommend.py --top 5`
 - **出力形式**: JSON + テキスト
 
+#### APIレスポンス仕様
+- 対象エンドポイント: `GET /recommendations?top_n=5`, `GET /recommendation/{symbol}`（いずれも README.md 110-117 行で定義）
+- **ランキングレスポンス共通フィールド**
+  - `generated_at` *(string, ISO 8601 datetime)*: 推奨結果の生成時刻。
+  - `top_n` *(integer)*: レスポンスに含まれる銘柄数。
+  - `items` *(array<object>)*: 銘柄ごとの推奨情報。
+- **ランキングアイテム必須フィールド**
+  - `symbol` *(string)*: 銘柄コード（例: "7203.T"）。
+  - `score` *(number)*: 推奨スコア（0〜100）。
+  - `action` *(string)*: 取るべきアクション（"buy"/"sell"/"hold" など）。
+  - `entry_price` *(object)*: 推奨エントリー価格。
+    - `min` *(number)*, `max` *(number)*: 価格帯を指定。
+  - `targets` *(array<object>)*: 目標価格のリスト。
+    - 各要素は `label` *(string)* と `price` *(number)* を含む。
+  - `stop_loss` *(number)*: 損切りライン。
+  - `holding_period_days` *(integer)*: 推奨保有日数の目安。
+- **銘柄詳細レスポンス必須フィールド**
+  - `symbol` *(string)*: 詳細情報の対象銘柄コード。
+  - `score` *(number)*: 現在の推奨スコア。
+  - `action` *(string)*: アクション種別。
+  - `rationale` *(string)*: モデルの推奨理由サマリ。
+  - `entry_price`, `targets`, `stop_loss`, `holding_period_days`: 上記ランキングアイテムと同様の構造。
+  - `indicators` *(object)*: 主要な技術指標（例: `sma20` *(number)*, `rsi14` *(number)* など）。
+- **オプション/拡張フィールド**
+  - `confidence` *(number)*: 予測信頼度（将来の拡張で追加可能）。
+  - `news_sentiment` *(object)*: ニュース/ SNS センチメント分析結果（「拡張性」方針に沿った発展要素）。
+  - `backtest` *(object)*: 過去検証データ（勝率や平均リターンなど）。
+
+##### JSONレスポンス例
+**ランキング（`GET /recommendations?top_n=5`）成功例**
+```json
+{
+  "generated_at": "2024-05-01T09:00:00Z",
+  "top_n": 3,
+  "items": [
+    {
+      "symbol": "7203.T",
+      "score": 87.5,
+      "action": "buy",
+      "entry_price": {"min": 3200, "max": 3300},
+      "targets": [
+        {"label": "base", "price": 3450},
+        {"label": "stretch", "price": 3600}
+      ],
+      "stop_loss": 3100,
+      "holding_period_days": 45
+    },
+    {
+      "symbol": "6758.T",
+      "score": 82.1,
+      "action": "buy",
+      "entry_price": {"min": 12000, "max": 12200},
+      "targets": [
+        {"label": "base", "price": 12900},
+        {"label": "stretch", "price": 13300}
+      ],
+      "stop_loss": 11700,
+      "holding_period_days": 60
+    },
+    {
+      "symbol": "9432.T",
+      "score": 74.3,
+      "action": "hold",
+      "entry_price": {"min": 4000, "max": 4050},
+      "targets": [{"label": "base", "price": 4200}],
+      "stop_loss": 3900,
+      "holding_period_days": 30
+    }
+  ]
+}
+```
+
+**銘柄詳細（`GET /recommendation/{symbol}`）成功例**
+```json
+{
+  "symbol": "7203.T",
+  "score": 87.5,
+  "action": "buy",
+  "rationale": "国内販売台数の伸びとテクニカル指標の改善に基づく買いシグナル。",
+  "entry_price": {"min": 3200, "max": 3300},
+  "targets": [
+    {"label": "base", "price": 3450},
+    {"label": "stretch", "price": 3600}
+  ],
+  "stop_loss": 3100,
+  "holding_period_days": 45,
+  "indicators": {
+    "sma20": 3150,
+    "sma60": 3050,
+    "rsi14": 58
+  },
+  "confidence": 0.78,
+  "news_sentiment": {
+    "score": 0.4,
+    "sources": ["nikkei", "reuters"]
+  }
+}
+```
+
+> **Note:** `confidence`、`news_sentiment`、`backtest` などのフィールドは将来拡張向けのオプション項目であり、応答で未使用の場合は省略される。API クライアントは未知フィールドを無視できるように実装し、拡張性と後方互換性を担保する。
+
 ### 第2段階（GUI）
 - **フロント**: React / Next.js
 - **可視化**: D3.js / Plotly


### PR DESCRIPTION
## Summary
- describe the JSON response structure for the recommendation ranking and per-symbol detail APIs
- document required fields, types, and optional extensions aligned with the API design
- add example payloads to guide clients on handling ranking and single-symbol responses

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd26eca8988321bf08deb5f5be599d