### PR TITLE
Use deterministic fallback seed for stock data

### DIFF
--- a/data/stock_data.py
+++ b/data/stock_data.py
@@ -10,6 +10,7 @@ tests).
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 from datetime import datetime, timedelta
@@ -30,7 +31,8 @@ logger = logging.getLogger(__name__)
 def _normalized_symbol_seed(symbol: str) -> int:
     """Return a deterministic, non-negative seed for a ticker symbol."""
 
-    return abs(hash(symbol)) % (2**32)
+    digest = hashlib.sha256(symbol.encode("utf-8", "surrogatepass")).digest()
+    return int.from_bytes(digest[:4], "big")
 
 
 def _period_to_days(period: str) -> int:


### PR DESCRIPTION
## Summary
- replace the fallback seed generation with a SHA-256 based deterministic hash
- update the stock data tests to load the real module and cover deterministic fallback behaviour
- add unit tests that assert the stable seed value and reproducible fallback history

## Testing
- pytest tests/unit/test_data/test_stock_data.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dd286b26948321b0904dd3f27b4ede