### PR TITLE
Use risk assessment score in full auto confidence

### DIFF
--- a/full_auto_system.py
+++ b/full_auto_system.py
@@ -555,7 +555,20 @@ class FullAutoInvestmentSystem:
                 strategy_confidence = max(
                     min(strategy.get('confidence_score', 0.0), 1.0), 0.0  # strategy から confidence_score を取得
                 )
-                risk_score = getattr(risk_analysis_for_payload, "total_risk_score", 0.5) if risk_analysis_for_payload else 0.5
+                if risk_analysis_for_payload:
+                    risk_score = getattr(risk_analysis_for_payload, "risk_score", None)
+                    if risk_score is None:
+                        raw_risk = getattr(risk_analysis_for_payload, "raw", None)
+                        if raw_risk is not None:
+                            risk_score = getattr(raw_risk, "total_risk_score", None)
+                    if risk_score is None:
+                        risk_score = getattr(risk_analysis_for_payload, "total_risk_score", 0.5)
+                else:
+                    risk_score = 0.5
+                try:
+                    risk_score = float(risk_score)
+                except (TypeError, ValueError):
+                    risk_score = 0.5
                 risk_adjusted_confidence = max(min(1.0 - risk_score, 1.0), 0.0)
                 # predictions から confidence を取得
                 prediction_confidence = predictions.get('confidence', 0.0)

--- a/sklearn/model_selection.py
+++ b/sklearn/model_selection.py
@@ -8,3 +8,11 @@ def train_test_split(*_, **__):  # pragma: no cover - placeholder
 
 def cross_val_score(*_, **__):  # pragma: no cover - placeholder
     raise RuntimeError("sklearn.model_selection is unavailable in this test environment")
+
+
+class TimeSeriesSplit:  # pragma: no cover - lightweight stub
+    def __init__(self, *_, **__):
+        pass
+
+    def split(self, *_args, **_kwargs):
+        return []

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,7 @@
 import sys
 import types
+from dataclasses import dataclass, field
+from datetime import datetime
 
 import pandas as pd
 
@@ -24,3 +26,53 @@ class _StubStockDataProvider:
 stock_data_stub.StockDataProvider = _StubStockDataProvider
 sys.modules["data.stock_data"] = stock_data_stub
 setattr(data_module, "stock_data", stock_data_stub)
+
+
+if "models" not in sys.modules:
+    models_module = types.ModuleType("models")
+    sys.modules["models"] = models_module
+else:
+    models_module = sys.modules["models"]
+
+recommendation_stub = types.ModuleType("models.recommendation")
+
+
+@dataclass
+class _StubStockRecommendation:
+    rank: int = 0
+    symbol: str = ""
+    company_name: str = ""
+    buy_timing: str = ""
+    target_price: float = 0.0
+    stop_loss: float = 0.0
+    profit_target_1: float = 0.0
+    profit_target_2: float = 0.0
+    holding_period: str = ""
+    score: float = 0.0
+    current_price: float = 0.0
+    recommendation_reason: str = ""
+    recommendation_level: str = "neutral"
+    generated_at: datetime = field(default_factory=datetime.utcnow)
+
+    def to_dict(self):  # pragma: no cover - compatibility helper
+        return {
+            "rank": self.rank,
+            "symbol": self.symbol,
+            "company_name": self.company_name,
+            "buy_timing": self.buy_timing,
+            "target_price": self.target_price,
+            "stop_loss": self.stop_loss,
+            "profit_target_1": self.profit_target_1,
+            "profit_target_2": self.profit_target_2,
+            "holding_period": self.holding_period,
+            "score": self.score,
+            "current_price": self.current_price,
+            "recommendation_reason": self.recommendation_reason,
+            "recommendation_level": self.recommendation_level,
+            "generated_at": self.generated_at.isoformat(),
+        }
+
+
+recommendation_stub.StockRecommendation = _StubStockRecommendation
+sys.modules["models.recommendation"] = recommendation_stub
+setattr(models_module, "recommendation", recommendation_stub)

--- a/tests/systems/test_full_auto_system_confidence.py
+++ b/tests/systems/test_full_auto_system_confidence.py
@@ -1,0 +1,205 @@
+import sys
+import types
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+
+def _ensure_module(path: str) -> types.ModuleType:
+    parts = path.split(".")
+    module: types.ModuleType | None = None
+    for idx in range(len(parts)):
+        name = ".".join(parts[: idx + 1])
+        if name not in sys.modules:
+            module = types.ModuleType(name)
+            sys.modules[name] = module
+            if idx > 0:
+                parent = sys.modules[".".join(parts[:idx])]
+                setattr(parent, parts[idx], module)
+        else:
+            module = sys.modules[name]
+    assert module is not None
+    return module
+
+
+hybrid_module = _ensure_module("models_new.hybrid.hybrid_predictor")
+
+
+class _StubHybridStockPredictor:
+    def predict(self, symbol: str):  # pragma: no cover - default stub behaviour
+        return SimpleNamespace(
+            prediction=0.0,
+            confidence=0.0,
+            accuracy=0.0,
+            metadata={},
+            symbol=symbol,
+            timestamp=datetime.now(),
+        )
+
+
+hybrid_module.HybridStockPredictor = _StubHybridStockPredictor
+
+
+analysis_module = _ensure_module("analysis.sentiment_analyzer")
+
+
+class _StubMarketSentimentAnalyzer:
+    def analyze_news_sentiment(self, symbol: str):  # pragma: no cover - stub
+        return {"sentiment_score": 0.0}
+
+
+analysis_module.MarketSentimentAnalyzer = _StubMarketSentimentAnalyzer
+
+
+trading_analysis_module = _ensure_module("trading.tse.analysis")
+
+
+@dataclass
+class _StubStockProfile:
+    symbol: str
+    sector: str
+    market_cap: float
+    volatility: float
+    profit_potential: float
+    diversity_score: float
+    combined_score: float
+
+
+trading_analysis_module.StockProfile = _StubStockProfile
+
+
+trading_optimizer_module = _ensure_module("trading.tse.optimizer")
+
+
+class _StubPortfolioOptimizer:
+    def optimize_portfolio(self, profiles):  # pragma: no cover - stub
+        return {"selected_stocks": [p.symbol for p in profiles[:5]]}
+
+
+trading_optimizer_module.PortfolioOptimizer = _StubPortfolioOptimizer
+
+
+strategy_module = _ensure_module("models_new.advanced.trading_strategy_generator")
+
+
+class _StubActionType(Enum):
+    BUY = "buy"
+    SELL = "sell"
+
+
+class _StubStrategyGenerator:
+    def generate_strategy(self, *_, **__):  # pragma: no cover - stub
+        return {}
+
+
+class _StubSignalGenerator:
+    def generate_signals(self, *_, **__):  # pragma: no cover - stub
+        return []
+
+
+strategy_module.ActionType = _StubActionType
+strategy_module.StrategyGenerator = _StubStrategyGenerator
+strategy_module.SignalGenerator = _StubSignalGenerator
+
+
+risk_module = _ensure_module("models_new.advanced.risk_management_framework")
+
+
+class _StubRiskLevel(Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+@dataclass
+class _StubPortfolioRisk:
+    total_risk_score: float = 0.5
+    risk_level: _StubRiskLevel = _StubRiskLevel.MEDIUM
+    individual_metrics: dict | None = None
+    risk_breakdown: dict | None = None
+    recommendations: list | None = None
+    max_safe_position_size: float = 0.1
+    timestamp: datetime = datetime.now()
+
+
+class _StubRiskManager:
+    def analyze_portfolio_risk(self, *_, **__):  # pragma: no cover - stub
+        return _StubPortfolioRisk()
+
+
+risk_module.RiskLevel = _StubRiskLevel
+risk_module.PortfolioRisk = _StubPortfolioRisk
+risk_module.RiskManager = _StubRiskManager
+
+
+archive_module = _ensure_module("archive.old_systems.medium_term_prediction")
+
+
+class _StubMediumTermPredictionSystem:
+    pass
+
+
+archive_module.MediumTermPredictionSystem = _StubMediumTermPredictionSystem
+
+
+script_module = _ensure_module("data_retrieval_script_generator")
+script_module.generate_colab_data_retrieval_script = lambda *_, **__: ""
+
+
+settings_module = _ensure_module("config.settings")
+settings_module.get_settings = lambda: SimpleNamespace()
+
+
+from full_auto_system import FullAutoInvestmentSystem, RiskAssessment
+from models_new.advanced.risk_management_framework import RiskLevel
+
+
+@pytest.mark.asyncio
+async def test_analyze_single_stock_uses_risk_assessment_score():
+    system = FullAutoInvestmentSystem()
+
+    system.predictor = SimpleNamespace(
+        predict=lambda symbol, data: {
+            "predicted_price": float(data["Close"].iloc[-1]) + 5.0,
+            "confidence": 0.31,
+        }
+    )
+
+    distinctive_risk_score = 0.23
+    risk_assessment = RiskAssessment(
+        risk_score=distinctive_risk_score,
+        risk_level=RiskLevel.LOW,
+        max_safe_position_size=0.5,
+        recommendations=["Hold"],
+        raw=SimpleNamespace(total_risk_score=0.81),
+    )
+    system.risk_manager = SimpleNamespace(analyze_risk=lambda *args, **kwargs: risk_assessment)
+
+    system.sentiment_analyzer = SimpleNamespace(
+        analyze_sentiment=lambda symbol: {"sentiment_score": 0.12}
+    )
+
+    system.strategy_generator = SimpleNamespace(
+        generate_strategy=lambda *args, **kwargs: {
+            "entry_price": 100.0,
+            "confidence_score": 0.7,
+            "expected_return": 0.15,
+            "stop_loss_pct": 0.05,
+            "take_profit_pct": 0.15,
+        }
+    )
+
+    data = pd.DataFrame(
+        {"Close": [95.0, 100.0]},
+        index=pd.date_range(datetime(2024, 1, 1), periods=2),
+    )
+
+    recommendation = await system._analyze_single_stock("MOCK", data)
+
+    assert recommendation is not None
+    expected_confidence = (0.7 + (1 - distinctive_risk_score) + 0.31) / 3
+    assert recommendation.confidence == pytest.approx(expected_confidence)


### PR DESCRIPTION
## Summary
- update the full auto recommendation confidence calculation to prioritise `RiskAssessment.risk_score` and gracefully fall back to raw totals when absent
- add lightweight testing shims and a regression test that injects a mocked risk assessment to verify the new confidence weighting
- extend the local sklearn stub with `TimeSeriesSplit` so imports succeed during the new system test

## Testing
- `pytest tests/systems/test_full_auto_system_confidence.py`
- `pytest tests/systems` *(fails: existing ProcessManager delegation/resource monitor tests fail under the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd270c7fa88321bdc0bb9bffc3b58f