### PR TITLE
Add security header test and middleware initialization

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ import uvicorn
 
 from api.endpoints import router
 from api.secure_endpoints import router as secure_router
+from api.security import add_security_middleware
 # from models.recommendation import StockRecommendation # 削除
 
 app = FastAPI(
@@ -11,6 +12,8 @@ app = FastAPI(
     description="初心者向け株式銘柄推奨システム",
     version="1.0.0",
 )
+
+add_security_middleware(app)
 
 app.include_router(router, prefix="/api/v1")
 app.include_router(secure_router, prefix="/api/v1")

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -158,6 +158,23 @@ def test_get_recommendations_returns_closed_after_15(monkeypatch):
     assert response.json()["market_status"] == "市場営業時間外"
 
 
+def test_health_endpoint_includes_security_headers():
+    from app.main import app as main_app
+
+    client = TestClient(main_app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("X-Frame-Options") == "DENY"
+    assert response.headers.get("X-XSS-Protection") == "1; mode=block"
+    assert (
+        response.headers.get("Strict-Transport-Security")
+        == "max-age=31536000; includeSubDomains"
+    )
+
+
 @patch("api.endpoints.verify_token")
 @patch("api.endpoints.MLStockPredictor")
 @patch("api.endpoints.StockDataProvider")


### PR DESCRIPTION
## Summary
- add a regression test to ensure the /health endpoint returns the expected security headers
- initialize the FastAPI security middleware immediately after creating the application instance

## Testing
- `pytest tests/test_api_endpoints.py -k health_endpoint_includes_security_headers` *(fails: ModuleNotFoundError: No module named 'models.core'; 'models' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68dd985ac7c48321a6885ef2ae5320a5