### PR TITLE
Adjust actual ticker handling for stock data

### DIFF
--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -159,6 +159,15 @@ async def get_stock_data(
             )
 
         technical_data = data_provider.calculate_technical_indicators(data)
+        actual_ticker = lookup_symbol
+        if "ActualTicker" in technical_data.columns:
+            actual_ticker_series = technical_data["ActualTicker"].dropna()
+            if not actual_ticker_series.empty:
+                latest_actual_ticker = actual_ticker_series.iloc[-1]
+                if pd.notna(latest_actual_ticker):
+                    latest_actual_ticker = str(latest_actual_ticker).strip()
+                    if latest_actual_ticker:
+                        actual_ticker = latest_actual_ticker
         raw_financial_metrics = (
             data_provider.get_financial_metrics(lookup_symbol) or {}
         )
@@ -169,7 +178,7 @@ async def get_stock_data(
         financial_metrics["symbol"] = validated_symbol
         if "company_name" in financial_metrics or company_name != lookup_symbol:
             financial_metrics["company_name"] = company_name
-        financial_metrics.setdefault("actual_ticker", lookup_symbol)
+        financial_metrics.setdefault("actual_ticker", actual_ticker)
 
         current_price = float(technical_data["Close"].iloc[-1])
         price_change = 0.0


### PR DESCRIPTION
## Summary
- derive the actual ticker from the technical indicator results before adjusting the financial metrics payload
- keep the original symbol fallback when the technical data lacks an ActualTicker entry and reuse it when populating financial metrics
- add a regression test that mocks empty financial metrics and confirms the response uses the technical data ticker with the requested suffix

## Testing
- ```
  python - <<'PY'
  import sys, os, types, pytest
  sys.path.insert(0, os.getcwd())
  joblib_module = types.ModuleType("joblib")
  joblib_module.dump = lambda *a, **k: None
  joblib_module.load = lambda *a, **k: None
  sys.modules.setdefault("joblib", joblib_module)
  models_module = types.ModuleType("models")
  core_module = types.ModuleType("models.core")
  class MLStockPredictor:
      def __init__(self, *args, **kwargs):
          pass
  models_module.core = core_module
  core_module.MLStockPredictor = MLStockPredictor
  sys.modules.setdefault("models", models_module)
  sys.modules.setdefault("models.core", core_module)
  raise SystemExit(pytest.main(["tests/test_api_endpoints.py::test_get_stock_data_actual_ticker_prefers_technical_data", "-vv"]))
  PY
  ```

------
https://chatgpt.com/codex/tasks/task_e_68dda53dcfd083218ea8351e2540b374