### PR TITLE
Use technical ActualTicker for stock data responses

### DIFF
--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -159,6 +159,11 @@ async def get_stock_data(
             )
 
         technical_data = data_provider.calculate_technical_indicators(data)
+        actual_ticker_value = lookup_symbol
+        if "ActualTicker" in technical_data.columns:
+            latest_actual_ticker = technical_data["ActualTicker"].dropna()
+            if not latest_actual_ticker.empty:
+                actual_ticker_value = str(latest_actual_ticker.iloc[-1])
         raw_financial_metrics = (
             data_provider.get_financial_metrics(lookup_symbol) or {}
         )
@@ -169,7 +174,7 @@ async def get_stock_data(
         financial_metrics["symbol"] = validated_symbol
         if "company_name" in financial_metrics or company_name != lookup_symbol:
             financial_metrics["company_name"] = company_name
-        financial_metrics.setdefault("actual_ticker", lookup_symbol)
+        financial_metrics.setdefault("actual_ticker", actual_ticker_value)
 
         current_price = float(technical_data["Close"].iloc[-1])
         price_change = 0.0

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -2,6 +2,10 @@ import os
 import pandas as pd
 from datetime import datetime
 from zoneinfo import ZoneInfo
+import sys
+import types
+from dataclasses import dataclass, field
+from datetime import datetime as dt_datetime
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -9,6 +13,62 @@ from unittest.mock import MagicMock, patch
 
 os.environ.setdefault("CLSTOCK_DEV_KEY", "test-key")
 os.environ.setdefault("CLSTOCK_ADMIN_KEY", "admin-key")
+
+
+class _StubMLStockPredictor:
+    pass
+
+
+@dataclass
+class _StubStockRecommendation:
+    rank: int = 0
+    symbol: str = ""
+    company_name: str = ""
+    buy_timing: str = ""
+    target_price: float = 0.0
+    stop_loss: float = 0.0
+    profit_target_1: float = 0.0
+    profit_target_2: float = 0.0
+    holding_period: str = ""
+    score: float = 0.0
+    current_price: float = 0.0
+    recommendation_reason: str = ""
+    recommendation_level: str = "neutral"
+    generated_at: dt_datetime = field(default_factory=dt_datetime.utcnow)
+
+    def to_dict(self):
+        return {
+            "rank": self.rank,
+            "symbol": self.symbol,
+            "company_name": self.company_name,
+            "buy_timing": self.buy_timing,
+            "target_price": self.target_price,
+            "stop_loss": self.stop_loss,
+            "profit_target_1": self.profit_target_1,
+            "profit_target_2": self.profit_target_2,
+            "holding_period": self.holding_period,
+            "score": self.score,
+            "current_price": self.current_price,
+            "recommendation_reason": self.recommendation_reason,
+            "recommendation_level": self.recommendation_level,
+            "generated_at": self.generated_at.isoformat(),
+        }
+
+
+sys.modules.setdefault("joblib", types.ModuleType("joblib"))
+_models_pkg = sys.modules.setdefault("models", types.ModuleType("models"))
+sys.modules.setdefault("models.core", types.ModuleType("models.core"))
+sys.modules.setdefault(
+    "models.recommendation", types.ModuleType("models.recommendation")
+)
+setattr(sys.modules["models.core"], "MLStockPredictor", _StubMLStockPredictor)
+setattr(_models_pkg, "core", sys.modules["models.core"])
+setattr(
+    sys.modules["models.recommendation"],
+    "StockRecommendation",
+    _StubStockRecommendation,
+)
+setattr(_models_pkg, "recommendation", sys.modules["models.recommendation"])
 
 from api.endpoints import router
 from models.recommendation import StockRecommendation
@@ -87,6 +147,41 @@ def test_get_stock_data_accepts_suffix_symbols(mock_provider_cls):
     payload = response.json()
     assert payload["financial_metrics"]["symbol"] == "7203.T"
     assert payload["financial_metrics"]["actual_ticker"] == "7203"
+
+
+@patch("api.endpoints.StockDataProvider")
+def test_get_stock_data_uses_actual_ticker_from_technical_data(mock_provider_cls):
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    mock_provider = MagicMock()
+    mock_provider.get_all_stock_symbols.return_value = {"7203": "Test Corp"}
+
+    technical_df = pd.DataFrame(
+        {
+            "Close": [300.0, 310.0],
+            "Volume": [3500, 3600],
+            "SMA_20": [None, None],
+            "SMA_50": [None, None],
+            "RSI": [None, None],
+            "MACD": [None, None],
+            "ActualTicker": ["7203.T", "7203.T"],
+        },
+        index=pd.date_range("2024-03-01", periods=2),
+    )
+
+    mock_provider.get_stock_data.return_value = technical_df
+    mock_provider.calculate_technical_indicators.return_value = technical_df
+    mock_provider.get_financial_metrics.return_value = {}
+
+    mock_provider_cls.return_value = mock_provider
+
+    response = client.get("/stock/7203.T/data?period=1mo")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["financial_metrics"]["actual_ticker"] == "7203.T"
 
 
 @patch("api.endpoints.StockDataProvider")


### PR DESCRIPTION
## Summary
- derive the actual ticker from the technical indicator data, falling back to the lookup symbol when needed
- update the FastAPI endpoint tests with lightweight stubs and add coverage for returning the suffixed actual ticker when financial metrics are empty

## Testing
- PYTHONPATH=. pytest tests/test_api_endpoints.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb8f9d6788321ad88ac0325528159