### PR TITLE
Centralize target symbol universe

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional
 
 from utils.cache import get_cache
 from utils.logger_config import setup_logger
+from .target_universe import get_target_universe
 
 logger = setup_logger(__name__)
 
@@ -301,39 +302,7 @@ class AppSettings:
 
     # 蟇ｾ雎｡驫俶氛
     target_stocks: Dict[str, str] = field(
-        default_factory=lambda: {
-            "7203": "Toyota Motor Corp",
-            "6758": "Sony Group Corp",
-            "9432": "Nippon Telegraph and Telephone",
-            "9434": "SoftBank Corp",
-            "6701": "NEC Corp",
-            "8316": "Sumitomo Mitsui Financial Group",
-            "8411": "Mizuho Financial Group",
-            "8306": "MUFG Bank",
-            "8058": "Mitsubishi Corp",
-            "8001": "Itochu Corp",
-            "8002": "Marubeni Corp",
-            "8031": "Mitsui & Co",
-            "6902": "Denso Corp",
-            "7267": "Honda Motor Co",
-            "6501": "Hitachi Ltd",
-            "6503": "Mitsubishi Electric",
-            "7751": "Canon Inc",
-            "8035": "Tokyo Electron",
-            "6770": "Alps Alpine",
-            "9433": "KDDI Corp",
-            "6502": "Toshiba Corp",
-            "6752": "Panasonic Holdings",
-            "6954": "Fanuc Corp",
-            "6861": "Keyence Corp",
-            "4523": "Eisai Co",
-            "4578": "Otsuka Holdings",
-            "7201": "Nissan Motor Co",
-            "7261": "Mazda Motor Corp",
-            "7269": "Suzuki Motor Corp",
-            "4901": "Fujifilm Holdings",
-            "4502": "Takeda Pharmaceutical",
-        }
+        default_factory=lambda: get_target_universe().english_names
     )
 
 

--- a/config/target_universe.py
+++ b/config/target_universe.py
@@ -1,0 +1,157 @@
+"""Authoritative target universe definitions.
+
+The canonical representation for tickers within the project is the base
+Japanese stock code (e.g. ``"7203"``). Exchange-specific variants such
+as ``"7203.T"`` are generated on demand via :class:`TargetUniverse`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class TargetSymbol:
+    """Metadata for a single target stock symbol."""
+
+    code: str
+    english_name: str
+    japanese_name: str
+    is_core: bool = False
+
+
+@dataclass(frozen=True)
+class TargetUniverse:
+    """Container exposing canonical stock codes and formatting helpers."""
+
+    symbols: Tuple[TargetSymbol, ...]
+    default_suffix: str = ".T"
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple dataclass wiring
+        object.__setattr__(self, "_by_code", {symbol.code: symbol for symbol in self.symbols})
+
+    @property
+    def base_codes(self) -> List[str]:
+        """Return all canonical stock codes in their base form."""
+        return [symbol.code for symbol in self.symbols]
+
+    @property
+    def default_codes(self) -> List[str]:
+        """Return the subset of core codes used for default trading contexts."""
+        defaults = [symbol.code for symbol in self.symbols if symbol.is_core]
+        return defaults or self.base_codes
+
+    def format_codes(self, codes: Iterable[str], suffix: str | None = None) -> List[str]:
+        """Format the given codes with the desired suffix (``.T`` by default)."""
+        suffix = self.default_suffix if suffix is None else suffix
+        return [f"{self.to_base(code)}{suffix}" for code in codes]
+
+    def default_formatted(self, suffix: str | None = None) -> List[str]:
+        """Return the formatted list of default/core symbols."""
+        return self.format_codes(self.default_codes, suffix=suffix)
+
+    def all_formatted(self, suffix: str | None = None) -> List[str]:
+        """Return the formatted list of all symbols in the universe."""
+        return self.format_codes(self.base_codes, suffix=suffix)
+
+    def variants_for(
+        self, code: str, *, suffixes: Sequence[str] | None = None
+    ) -> List[str]:
+        """Return the base code and formatted variants for the requested symbol."""
+        base = self.to_base(code)
+        suffixes = tuple(suffixes) if suffixes is not None else (self.default_suffix,)
+        variants = [base]
+        variants.extend(f"{base}{suffix}" for suffix in suffixes)
+        return variants
+
+    @staticmethod
+    def to_base(code: str) -> str:
+        """Normalise any ticker variant back to its canonical base code."""
+        return code.split(".", 1)[0]
+
+    @property
+    def english_names(self) -> Dict[str, str]:
+        """Mapping of base codes to English company names."""
+        return {code: symbol.english_name for code, symbol in self._by_code.items()}
+
+    @property
+    def japanese_names(self) -> Dict[str, str]:
+        """Mapping of base codes to Japanese company names."""
+        return {code: symbol.japanese_name for code, symbol in self._by_code.items()}
+
+
+# Ordered catalogue of target symbols. Core/default symbols appear first to
+# preserve historical behaviour for backtests and demo trading.
+_TARGET_SYMBOLS: Tuple[TargetSymbol, ...] = (
+    TargetSymbol("6758", "Sony Group Corp", "ソニーグループ", is_core=True),
+    TargetSymbol("7203", "Toyota Motor Corp", "トヨタ自動車", is_core=True),
+    TargetSymbol("8306", "MUFG Bank", "三菱UFJフィナンシャル・グループ", is_core=True),
+    TargetSymbol("9984", "SoftBank Group Corp", "ソフトバンクグループ", is_core=True),
+    TargetSymbol("6861", "Keyence Corp", "キーエンス", is_core=True),
+    TargetSymbol("4502", "Takeda Pharmaceutical", "武田薬品工業", is_core=True),
+    TargetSymbol("6503", "Mitsubishi Electric", "三菱電機", is_core=True),
+    TargetSymbol("7201", "Nissan Motor Co", "日産自動車", is_core=True),
+    TargetSymbol("8001", "Itochu Corp", "伊藤忠商事", is_core=True),
+    TargetSymbol("9022", "East Japan Railway Co", "東日本旅客鉄道", is_core=True),
+    TargetSymbol("7267", "Honda Motor Co", "ホンダ"),
+    TargetSymbol("7261", "Mazda Motor Corp", "マツダ"),
+    TargetSymbol("7269", "Suzuki Motor Corp", "スズキ"),
+    TargetSymbol("6902", "Denso Corp", "デンソー"),
+    TargetSymbol("6752", "Panasonic Holdings", "パナソニック"),
+    TargetSymbol("6701", "NEC Corp", "NEC"),
+    TargetSymbol("6702", "Fujitsu Ltd", "富士通"),
+    TargetSymbol("6501", "Hitachi Ltd", "日立製作所"),
+    TargetSymbol("6502", "Toshiba Corp", "東芝"),
+    TargetSymbol("6954", "Fanuc Corp", "ファナック"),
+    TargetSymbol("6981", "Murata Manufacturing Co", "村田製作所"),
+    TargetSymbol("6971", "Kyocera Corp", "京セラ"),
+    TargetSymbol("7751", "Canon Inc", "キヤノン"),
+    TargetSymbol("8035", "Tokyo Electron", "東京エレクトロン"),
+    TargetSymbol("6770", "Alps Alpine", "アルプスアルパイン"),
+    TargetSymbol("9432", "Nippon Telegraph and Telephone", "日本電信電話"),
+    TargetSymbol("9433", "KDDI Corp", "KDDI"),
+    TargetSymbol("9434", "SoftBank Corp", "ソフトバンク"),
+    TargetSymbol("9437", "NTT Docomo Inc", "NTTドコモ"),
+    TargetSymbol("6098", "Recruit Holdings Co", "リクルートホールディングス"),
+    TargetSymbol("9613", "NTT Data Corp", "NTTデータ"),
+    TargetSymbol("8316", "Sumitomo Mitsui Financial Group", "三井住友フィナンシャルグループ"),
+    TargetSymbol("8411", "Mizuho Financial Group", "みずほフィナンシャルグループ"),
+    TargetSymbol("8604", "Nomura Holdings", "野村ホールディングス"),
+    TargetSymbol("8058", "Mitsubishi Corp", "三菱商事"),
+    TargetSymbol("8002", "Marubeni Corp", "丸紅"),
+    TargetSymbol("8031", "Mitsui & Co", "三井物産"),
+    TargetSymbol("8053", "Sumitomo Corp", "住友商事"),
+    TargetSymbol("4005", "Sumitomo Chemical Co", "住友化学"),
+    TargetSymbol("4063", "Shin-Etsu Chemical Co", "信越化学工業"),
+    TargetSymbol("4503", "Astellas Pharma Inc", "アステラス製薬"),
+    TargetSymbol("4507", "Shionogi & Co", "塩野義製薬"),
+    TargetSymbol("4523", "Eisai Co", "エーザイ"),
+    TargetSymbol("4578", "Otsuka Holdings", "大塚ホールディングス"),
+    TargetSymbol("5401", "Nippon Steel Corp", "日本製鉄"),
+    TargetSymbol("5713", "Sumitomo Metal Mining Co", "住友金属鉱山"),
+    TargetSymbol("5020", "ENEOS Holdings", "ENEOS"),
+    TargetSymbol("7974", "Nintendo Co", "任天堂"),
+    TargetSymbol("8267", "Aeon Co", "イオン"),
+    TargetSymbol("9983", "Fast Retailing Co", "ファーストリテイリング"),
+    TargetSymbol("3382", "Seven & i Holdings Co", "セブン&アイ・ホールディングス"),
+    TargetSymbol("2914", "Japan Tobacco Inc", "日本たばこ産業"),
+    TargetSymbol("2802", "Ajinomoto Co", "味の素"),
+    TargetSymbol("4911", "Shiseido Co", "資生堂"),
+    TargetSymbol("8802", "Mitsubishi Estate Co", "三菱地所"),
+    TargetSymbol("8801", "Mitsui Fudosan Co", "三井不動産"),
+    TargetSymbol("1801", "Taisei Corp", "大成建設"),
+    TargetSymbol("6367", "Daikin Industries Ltd", "ダイキン工業"),
+    TargetSymbol("4901", "Fujifilm Holdings", "富士フイルム"),
+)
+
+_TARGET_UNIVERSE = TargetUniverse(symbols=_TARGET_SYMBOLS)
+
+
+def get_target_universe() -> TargetUniverse:
+    """Return the immutable global target universe definition."""
+
+    return _TARGET_UNIVERSE
+
+
+__all__ = ["TargetSymbol", "TargetUniverse", "get_target_universe"]

--- a/investment_advisor_cui.py
+++ b/investment_advisor_cui.py
@@ -23,6 +23,7 @@ from models_new.hybrid.prediction_modes import PredictionMode
 from data.stock_data import StockDataProvider
 from data.sector_classification import SectorClassification
 from archive.old_systems.medium_term_prediction import MediumTermPredictionSystem
+from config.target_universe import get_target_universe
 
 
 class InvestmentAdvisorCUI:
@@ -34,124 +35,9 @@ class InvestmentAdvisorCUI:
         self.data_provider = StockDataProvider()
         self.medium_system = MediumTermPredictionSystem()
 
-        # 推奨銘柄リスト（ブルーチップ中心45銘柄）
-        self.target_symbols = [
-            # 自動車・輸送機器（安定大手のみ）
-            "7203.T",  # トヨタ自動車
-            "7267.T",  # ホンダ
-            "7201.T",  # 日産自動車
-            "7269.T",  # スズキ
-            # 電機・精密機器（ブルーチップ）
-            "6758.T",  # ソニーグループ
-            "6861.T",  # キーエンス
-            "6954.T",  # ファナック
-            "6981.T",  # 村田製作所
-            "6503.T",  # 三菱電機
-            "6702.T",  # 富士通
-            "6752.T",  # パナソニック
-            "6971.T",  # 京セラ
-            "7751.T",  # キヤノン
-            # 通信・IT（安定大手）
-            "9984.T",  # ソフトバンクグループ
-            "9433.T",  # KDDI
-            "9434.T",  # NTT
-            "9437.T",  # NTTドコモ
-            "6098.T",  # リクルートホールディングス
-            "9613.T",  # NTTデータ
-            # 金融（メガバンク・大手証券）
-            "8306.T",  # 三菱UFJ
-            "8316.T",  # 三井住友フィナンシャル
-            "8411.T",  # みずほフィナンシャル
-            "8604.T",  # 野村ホールディングス
-            # 商社（5大商社）
-            "8001.T",  # 伊藤忠商事
-            "8058.T",  # 三菱商事
-            "8031.T",  # 三井物産
-            "8053.T",  # 住友商事
-            "8002.T",  # 丸紅
-            # 医薬品・化学（安定大手）
-            "4502.T",  # 武田薬品工業
-            "4507.T",  # 塩野義製薬
-            "4503.T",  # アステラス製薬
-            "4005.T",  # 住友化学
-            "4063.T",  # 信越化学工業
-            # 素材・エネルギー（安定大手）
-            "5401.T",  # 新日鉄住金
-            "5713.T",  # 住友金属鉱山
-            "5020.T",  # ENEOS
-            # 消費・小売（ブルーチップ）
-            "7974.T",  # 任天堂
-            "8267.T",  # イオン
-            "9983.T",  # ファーストリテイリング
-            "3382.T",  # セブン&アイ
-            "2914.T",  # JT
-            "2802.T",  # 味の素
-            "4911.T",  # 資生堂
-            # 不動産・建設（安定大手）
-            "8802.T",  # 三菱地所
-            "8801.T",  # 三井不動産
-            "1801.T",  # 大成建設
-            "6367.T",  # ダイキン工業
-        ]
-
-        self.symbol_names = {
-            # 自動車・輸送機器
-            "7203.T": "トヨタ自動車",
-            "7267.T": "ホンダ",
-            "7201.T": "日産自動車",
-            "7269.T": "スズキ",
-            # 電機・精密機器
-            "6758.T": "ソニーグループ",
-            "6861.T": "キーエンス",
-            "6954.T": "ファナック",
-            "6981.T": "村田製作所",
-            "6503.T": "三菱電機",
-            "6702.T": "富士通",
-            "6752.T": "パナソニック",
-            "6971.T": "京セラ",
-            "7751.T": "キヤノン",
-            # 通信・IT
-            "9984.T": "ソフトバンクG",
-            "9433.T": "KDDI",
-            "9434.T": "NTT",
-            "9437.T": "NTTドコモ",
-            "6098.T": "リクルート",
-            "9613.T": "NTTデータ",
-            # 金融
-            "8306.T": "三菱UFJ",
-            "8316.T": "三井住友FG",
-            "8411.T": "みずほFG",
-            "8604.T": "野村HD",
-            # 商社
-            "8001.T": "伊藤忠商事",
-            "8058.T": "三菱商事",
-            "8031.T": "三井物産",
-            "8053.T": "住友商事",
-            "8002.T": "丸紅",
-            # 医薬品・化学
-            "4502.T": "武田薬品",
-            "4507.T": "塩野義製薬",
-            "4503.T": "アステラス製薬",
-            "4005.T": "住友化学",
-            "4063.T": "信越化学",
-            # 素材・エネルギー
-            "5401.T": "新日鉄住金",
-            "5713.T": "住友金属鉱山",
-            "5020.T": "ENEOS",
-            # 消費・小売
-            "7974.T": "任天堂",
-            "8267.T": "イオン",
-            "9983.T": "ファーストリテイリング",
-            "3382.T": "セブン&アイ",
-            "2914.T": "JT",
-            "2802.T": "味の素",
-            "4911.T": "資生堂",
-            # 不動産・建設
-            "8802.T": "三菱地所",
-            "8801.T": "三井不動産",
-            "1801.T": "大成建設",
-            "6367.T": "ダイキン",
-        }
+        self.target_universe = get_target_universe()
+        self.target_symbols = self.target_universe.all_formatted()
+        self.symbol_names = self.target_universe.japanese_names
 
     def get_short_term_prediction(self, symbol: str) -> Dict[str, Any]:
         """短期予測（1日、90.3%精度）"""
@@ -208,7 +94,7 @@ class InvestmentAdvisorCUI:
 
         return {
             "symbol": symbol,
-            "name": self.symbol_names.get(symbol, symbol),
+            "name": self.symbol_names.get(self.target_universe.to_base(symbol), symbol),
             "short_term": short_term,
             "medium_term": medium_term,
             "integrated_recommendation": recommendation,
@@ -349,8 +235,11 @@ class InvestmentAdvisorCUI:
         all_analyses = []
 
         for i, symbol in enumerate(self.target_symbols[:limit], 1):
+            name = self.symbol_names.get(
+                self.target_universe.to_base(symbol), symbol
+            )
             print(
-                f"分析進行: {i}/{min(limit, len(self.target_symbols))} - {self.symbol_names.get(symbol, symbol)}"
+                f"分析進行: {i}/{min(limit, len(self.target_symbols))} - {name}"
             )
 
             try:

--- a/tests/unit/test_config/test_config_dataclasses.py
+++ b/tests/unit/test_config/test_config_dataclasses.py
@@ -17,6 +17,7 @@ from config.settings import (
     get_settings,
     load_from_env,
 )
+from config.target_universe import get_target_universe
 
 
 class TestConfigDataclasses:
@@ -143,12 +144,6 @@ class TestSettingsIntegration:
     def test_target_stocks_config(self):
         """Test that target stocks are properly configured."""
         settings = get_settings()
+        universe = get_target_universe()
 
-        # Check that we have the expected number of target stocks
-        assert len(settings.target_stocks) >= 30  # Validate a reasonably sized universe
-
-        # Check a few specific stocks
-        assert "7203" in settings.target_stocks  # Toyota
-        assert "6758" in settings.target_stocks  # Sony
-        assert settings.target_stocks["7203"] == "Toyota Motor Corp"
-        assert settings.target_stocks["6758"] == "Sony Group Corp"
+        assert settings.target_stocks == universe.english_names

--- a/tests/unit/test_config/test_settings_comprehensive.py
+++ b/tests/unit/test_config/test_settings_comprehensive.py
@@ -18,6 +18,7 @@ from config.settings import (
     create_settings,
     get_settings,
 )
+from config.target_universe import get_target_universe
 
 
 class TestConfigurationSystem:
@@ -93,21 +94,9 @@ class TestConfigurationSystem:
     def test_target_stocks_completeness(self):
         """Test that target stocks configuration is complete."""
         settings = get_settings()
+        universe = get_target_universe()
 
-        # Should have at least 50 stocks (as mentioned in requirements)
-        assert len(settings.target_stocks) >= 30
-
-        # Check specific well-known stocks
-        expected_stocks = {
-            "7203": "Toyota Motor Corp",
-            "6758": "Sony Group Corp",
-            "9432": "Nippon Telegraph and Telephone",
-            "8316": "Sumitomo Mitsui Financial Group",
-        }
-
-        for code, name in expected_stocks.items():
-            assert code in settings.target_stocks
-            assert settings.target_stocks[code] == name
+        assert settings.target_stocks == universe.english_names
 
     @patch.dict(
         os.environ,

--- a/tests/unit/test_data/test_target_universe.py
+++ b/tests/unit/test_data/test_target_universe.py
@@ -1,0 +1,62 @@
+"""Tests for the central target universe helper."""
+
+import pytest
+
+from config.target_universe import get_target_universe
+
+
+EXPECTED_CORE_CODES = {
+    "6758",
+    "7203",
+    "8306",
+    "9984",
+    "6861",
+    "4502",
+    "6503",
+    "7201",
+    "8001",
+    "9022",
+}
+
+EXPECTED_CORE_ORDER = [
+    "6758",
+    "7203",
+    "8306",
+    "9984",
+    "6861",
+    "4502",
+    "6503",
+    "7201",
+    "8001",
+    "9022",
+]
+
+
+def test_target_universe_provides_base_codes():
+    """The helper should expose canonical base ticker codes without suffixes."""
+    universe = get_target_universe()
+
+    assert EXPECTED_CORE_CODES.issubset(set(universe.base_codes))
+    assert all("." not in code for code in universe.base_codes)
+
+
+@pytest.mark.parametrize("suffix", [".T", ".JP"])
+def test_target_universe_generates_variants(suffix: str):
+    """Variant lookups should include suffix formatted tickers."""
+    universe = get_target_universe()
+
+    formatted = universe.format_codes(universe.default_codes, suffix=suffix)
+
+    assert formatted == [f"{code}{suffix}" for code in universe.default_codes]
+    for code in EXPECTED_CORE_CODES:
+        variants = universe.variants_for(code, suffixes=[suffix])
+        assert f"{code}{suffix}" in variants
+        assert code in variants  # base code always included
+
+
+def test_target_universe_default_formatted_symbols():
+    """Default formatted list should match the configured core codes."""
+    universe = get_target_universe()
+
+    assert universe.default_codes == EXPECTED_CORE_ORDER
+    assert universe.default_formatted() == [f"{code}.T" for code in EXPECTED_CORE_ORDER]

--- a/tests/unit/test_investment_advisor_cui.py
+++ b/tests/unit/test_investment_advisor_cui.py
@@ -1,0 +1,68 @@
+"""Tests for the investment advisor CUI target symbol handling."""
+
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from config.target_universe import get_target_universe
+
+
+@pytest.fixture
+def advisor(monkeypatch):
+    """Provide an instance of InvestmentAdvisorCUI with lightweight dependencies."""
+    stub_modules = {
+        "models_new": types.ModuleType("models_new"),
+        "models_new.precision": types.ModuleType("models_new.precision"),
+        "models_new.precision.precision_87_system": types.ModuleType(
+            "models_new.precision.precision_87_system"
+        ),
+        "models_new.hybrid": types.ModuleType("models_new.hybrid"),
+        "models_new.hybrid.hybrid_predictor": types.ModuleType(
+            "models_new.hybrid.hybrid_predictor"
+        ),
+        "models_new.hybrid.prediction_modes": types.ModuleType(
+            "models_new.hybrid.prediction_modes"
+        ),
+        "archive": types.ModuleType("archive"),
+        "archive.old_systems": types.ModuleType("archive.old_systems"),
+        "archive.old_systems.medium_term_prediction": types.ModuleType(
+            "archive.old_systems.medium_term_prediction"
+        ),
+        "data": types.ModuleType("data"),
+        "data.stock_data": types.ModuleType("data.stock_data"),
+        "data.sector_classification": types.ModuleType("data.sector_classification"),
+    }
+
+    for name, module in stub_modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+        if name in {"models_new", "models_new.precision", "models_new.hybrid", "archive", "archive.old_systems", "data"}:
+            module.__path__ = []  # type: ignore[attr-defined]
+
+    stub_modules["models_new.precision.precision_87_system"].Precision87BreakthroughSystem = (  # type: ignore[attr-defined]
+        lambda: SimpleNamespace()
+    )
+    stub_modules["models_new.hybrid.hybrid_predictor"].HybridStockPredictor = (  # type: ignore[attr-defined]
+        lambda: SimpleNamespace()
+    )
+    stub_modules["models_new.hybrid.prediction_modes"].PredictionMode = SimpleNamespace()  # type: ignore[attr-defined]
+    stub_modules["archive.old_systems.medium_term_prediction"].MediumTermPredictionSystem = (  # type: ignore[attr-defined]
+        lambda: SimpleNamespace()
+    )
+    stub_modules["data.stock_data"].StockDataProvider = lambda: SimpleNamespace()  # type: ignore[attr-defined]
+    stub_modules["data.sector_classification"].SectorClassification = SimpleNamespace(  # type: ignore[attr-defined]
+        get_sector_risk=lambda symbol: 0.0
+    )
+
+    from investment_advisor_cui import InvestmentAdvisorCUI
+
+    return InvestmentAdvisorCUI()
+
+
+def test_investment_advisor_targets_from_universe(advisor):
+    """The advisor should mirror the target universe definitions."""
+    universe = get_target_universe()
+
+    assert advisor.target_symbols == universe.all_formatted()
+    assert set(advisor.symbol_names) == set(universe.base_codes)

--- a/tests/unit/test_trading/test_backtest_engine_defaults.py
+++ b/tests/unit/test_trading/test_backtest_engine_defaults.py
@@ -1,0 +1,17 @@
+"""Tests for the BacktestEngine default symbols."""
+
+import pytest
+
+pytest.importorskip("scipy.sparse")
+
+from config.target_universe import get_target_universe
+from trading.backtest_engine import BacktestEngine
+
+
+def test_backtest_engine_default_symbols_from_universe():
+    """BacktestEngine should draw its defaults from the shared universe."""
+    universe = get_target_universe()
+
+    defaults = BacktestEngine._get_default_symbols()
+
+    assert defaults == universe.default_formatted()

--- a/tests/unit/test_trading/test_demo_trader.py
+++ b/tests/unit/test_trading/test_demo_trader.py
@@ -4,6 +4,9 @@ from datetime import datetime
 
 import pytest
 
+pytest.importorskip("scipy.sparse")
+
+from config.target_universe import get_target_universe
 from trading.demo_trader import DemoSession, DemoTrader
 
 
@@ -44,3 +47,12 @@ def test_save_session_results_creates_directory_and_file(tmp_path, monkeypatch):
 
     assert data["session"]["session_id"] == "unit_test"
     assert target_dir.is_dir(), "Target directory should be created"
+
+
+def test_demo_trader_default_symbols_from_universe():
+    """The demo trader should rely on the shared target universe."""
+    universe = get_target_universe()
+
+    defaults = DemoTrader._get_default_symbols()
+
+    assert defaults == universe.default_formatted()

--- a/trading/backtest_engine.py
+++ b/trading/backtest_engine.py
@@ -34,6 +34,7 @@ from .backtest import (
 
 # 既存システム
 from data.stock_data import StockDataProvider
+from config.target_universe import get_target_universe
 from models_new.precision.precision_87_system import Precision87BreakthroughSystem
 
 
@@ -356,20 +357,10 @@ class BacktestEngine:
         # 平日のみ（簡略化）
         return date.weekday() < 5
 
-    def _get_default_symbols(self) -> List[str]:
+    @staticmethod
+    def _get_default_symbols() -> List[str]:
         """デフォルト銘柄リスト"""
-        return [
-            "6758.T",
-            "7203.T",
-            "8306.T",
-            "9984.T",
-            "6861.T",
-            "4502.T",
-            "6503.T",
-            "7201.T",
-            "8001.T",
-            "9022.T",
-        ]
+        return get_target_universe().default_formatted()
 
     def _empty_backtest_result(self) -> BacktestResult:
         """空のバックテスト結果"""

--- a/trading/demo_trader.py
+++ b/trading/demo_trader.py
@@ -27,6 +27,7 @@ from .trade_recorder import TradeRecorder
 
 # 既存システム
 from data.stock_data import StockDataProvider
+from config.target_universe import get_target_universe
 from models_new.precision.precision_87_system import Precision87BreakthroughSystem
 
 
@@ -610,20 +611,10 @@ class DemoTrader:
             return False
         return 9 <= now.hour < 15
 
-    def _get_default_symbols(self) -> List[str]:
+    @staticmethod
+    def _get_default_symbols() -> List[str]:
         """デフォルト対象銘柄取得"""
-        return [
-            "6758.T",
-            "7203.T",
-            "8306.T",
-            "9984.T",
-            "6861.T",  # 主要株
-            "4502.T",
-            "6503.T",
-            "7201.T",
-            "8001.T",
-            "9022.T",  # 追加株
-        ]
+        return get_target_universe().default_formatted()
 
     def _save_session_results(self):
         """セッション結果保存"""


### PR DESCRIPTION
## Summary
- add a dedicated `config.target_universe` helper that stores canonical ticker metadata and generates exchange-specific variants
- switch demo trading, backtesting, and the investment advisor to use the shared universe while standardising symbol lookups on base codes
- align configuration defaults and unit tests with the central universe and add focused coverage for the new helper

## Testing
- pytest tests/unit/test_data/test_target_universe.py -q
- pytest tests/unit/test_investment_advisor_cui.py -q
- pytest tests/unit/test_trading/test_demo_trader.py -q
- pytest tests/unit/test_trading/test_backtest_engine_defaults.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dde103e4b0832184dec8705a341e64