### PR TITLE
Refactor auto portfolio optimization with backtesting

### DIFF
--- a/tests/unit/test_full_auto_system.py
+++ b/tests/unit/test_full_auto_system.py
@@ -40,6 +40,102 @@ for module_name, class_name in [
 ]:
     _stub_module(module_name, class_name)
 
+if "sklearn" not in sys.modules:
+    sklearn_module = types.ModuleType("sklearn")
+    sys.modules["sklearn"] = sklearn_module
+else:
+    sklearn_module = sys.modules["sklearn"]
+
+sklearn_preprocessing = types.ModuleType("sklearn.preprocessing")
+
+
+class _DummyStandardScaler:
+    def fit_transform(self, data):
+        return data
+
+    def transform(self, data):
+        return data
+
+
+sklearn_preprocessing.StandardScaler = _DummyStandardScaler
+sys.modules["sklearn.preprocessing"] = sklearn_preprocessing
+setattr(sklearn_module, "preprocessing", sklearn_preprocessing)
+
+sklearn_metrics = types.ModuleType("sklearn.metrics")
+
+
+def _dummy_mean_squared_error(*args, **kwargs):
+    return 0.0
+
+
+sklearn_metrics.mean_squared_error = _dummy_mean_squared_error
+sklearn_metrics.mean_absolute_error = _dummy_mean_squared_error
+sklearn_metrics.mean_absolute_percentage_error = _dummy_mean_squared_error
+sklearn_metrics.r2_score = _dummy_mean_squared_error
+sklearn_metrics.explained_variance_score = _dummy_mean_squared_error
+
+
+def _metrics_getattr(name):
+    return _dummy_mean_squared_error
+
+
+sklearn_metrics.__getattr__ = _metrics_getattr
+sys.modules["sklearn.metrics"] = sklearn_metrics
+setattr(sklearn_module, "metrics", sklearn_metrics)
+
+sklearn_model_selection = types.ModuleType("sklearn.model_selection")
+
+
+class _DummyTimeSeriesSplit:
+    def split(self, X, y=None, groups=None):
+        indices = list(range(len(X))) if hasattr(X, '__len__') else [0]
+        yield indices, indices
+
+
+sklearn_model_selection.TimeSeriesSplit = _DummyTimeSeriesSplit
+sys.modules["sklearn.model_selection"] = sklearn_model_selection
+setattr(sklearn_module, "model_selection", sklearn_model_selection)
+
+if "scipy" not in sys.modules:
+    scipy_module = types.ModuleType("scipy")
+    sys.modules["scipy"] = scipy_module
+else:
+    scipy_module = sys.modules["scipy"]
+
+scipy_sparse = types.ModuleType("scipy.sparse")
+
+
+def _dummy_csr_matrix(*args, **kwargs):
+    return []
+
+
+scipy_sparse.csr_matrix = _dummy_csr_matrix
+scipy_sparse.issparse = lambda matrix: False
+sys.modules["scipy.sparse"] = scipy_sparse
+setattr(scipy_module, "sparse", scipy_sparse)
+
+if "torch" not in sys.modules:
+    torch_module = types.ModuleType("torch")
+    sys.modules["torch"] = torch_module
+else:
+    torch_module = sys.modules["torch"]
+
+if not hasattr(torch_module, 'tensor'):
+    torch_module.tensor = lambda *args, **kwargs: None
+    torch_module.no_grad = types.SimpleNamespace(__enter__=lambda self: None, __exit__=lambda self, exc_type, exc, tb: False)
+
+torch_cuda = types.ModuleType("torch.cuda")
+torch_cuda.is_available = lambda: False
+sys.modules["torch.cuda"] = torch_cuda
+setattr(torch_module, 'cuda', torch_cuda)
+
+torch_nn = types.ModuleType("torch.nn")
+torch_module.nn = torch_nn
+sys.modules["torch.nn"] = torch_nn
+
+torch_module.device = lambda *args, **kwargs: 'cpu'
+
+import full_auto_system
 from full_auto_system import (
     AutoRecommendation,
     FullAutoInvestmentSystem,
@@ -49,10 +145,6 @@ from models_new.base.interfaces import PredictionResult
 from models_new.advanced.risk_management_framework import (
     PortfolioRisk,
     RiskLevel,
-)
-from models_new.advanced.trading_strategy_generator import (
-    TradingStrategy,
-    StrategyType,
 )
 
 
@@ -68,8 +160,16 @@ async def test_analyze_single_stock_uses_new_components(monkeypatch):
         symbol="TEST",
         metadata={},
     )
+    prediction_payload = {
+        "predicted_price": prediction_result.prediction,
+        "confidence": prediction_result.confidence,
+        "accuracy": prediction_result.accuracy,
+        "timestamp": prediction_result.timestamp,
+        "symbol": prediction_result.symbol,
+        "metadata": prediction_result.metadata,
+    }
     predictor = SimpleNamespace()
-    predictor.predict = MagicMock(return_value=prediction_result)  # type: ignore[attr-defined]
+    predictor.predict = MagicMock(return_value=prediction_payload)  # type: ignore[attr-defined]
     system.predictor = predictor  # type: ignore[assignment]
 
     portfolio_risk = PortfolioRisk(
@@ -82,29 +182,34 @@ async def test_analyze_single_stock_uses_new_components(monkeypatch):
         timestamp=datetime.now(),
     )
     risk_manager = SimpleNamespace()
-    risk_manager.analyze_portfolio_risk = MagicMock(return_value=portfolio_risk)  # type: ignore[attr-defined]
+    risk_manager.analyze_risk = MagicMock(return_value=portfolio_risk)  # type: ignore[attr-defined]
     system.risk_manager = risk_manager  # type: ignore[assignment]
 
     sentiment_analyzer = SimpleNamespace()
-    sentiment_analyzer.analyze_news_sentiment = MagicMock(return_value=0.25)  # type: ignore[attr-defined]
+    sentiment_payload = {"sentiment_score": 0.25}
+    sentiment_analyzer.analyze_news_sentiment = MagicMock(return_value=sentiment_payload)  # type: ignore[attr-defined]
+    sentiment_analyzer.analyze_sentiment = MagicMock(return_value=sentiment_payload)  # type: ignore[attr-defined]
     system.sentiment_analyzer = sentiment_analyzer  # type: ignore[assignment]
 
-    trading_strategy = TradingStrategy(
-        name="TEST_Momentum",
-        strategy_type=StrategyType.MOMENTUM,
-        parameters={},
-        entry_conditions=[],
-        exit_conditions=[],
-        risk_management={"stop_loss_pct": 0.05, "take_profit_pct": 0.1},
-        expected_return=0.12,
-        max_drawdown=0.08,
-        sharpe_ratio=1.4,
-        win_rate=0.66,
-        created_at=datetime.now(),
+    strategy_payload = {
+        "entry_price": 102.0,
+        "stop_loss_pct": 0.05,
+        "take_profit_pct": 0.1,
+        "expected_return": 0.12,
+        "confidence_score": 0.66,
+    }
+    strategy_calls = []
+
+    def fake_generate_strategy(self, symbol, price_data, predictions, risk, sentiment):
+        strategy_calls.append((symbol, price_data, predictions, risk, sentiment))
+        return strategy_payload
+
+    monkeypatch.setattr(
+        full_auto_system.StrategyGeneratorAdapter,
+        "generate_strategy",
+        fake_generate_strategy,
+        raising=False,
     )
-    strategy_generator = SimpleNamespace()
-    strategy_generator.generate_momentum_strategy = MagicMock(return_value=trading_strategy)  # type: ignore[attr-defined]
-    system.strategy_generator = strategy_generator  # type: ignore[assignment]
 
     data = pd.DataFrame(
         {"Close": [100.0, 102.0], "High": [101.0, 103.0], "Low": [99.0, 101.0]},
@@ -117,30 +222,32 @@ async def test_analyze_single_stock_uses_new_components(monkeypatch):
     assert isinstance(recommendation, AutoRecommendation)
     assert recommendation.entry_price == pytest.approx(data["Close"].iloc[-1])
     assert recommendation.target_price == pytest.approx(
-        recommendation.entry_price * (1 + trading_strategy.expected_return)
+        recommendation.entry_price * (1 + strategy_payload["expected_return"])
     )
     assert recommendation.stop_loss == pytest.approx(
-        recommendation.entry_price * (1 - trading_strategy.risk_management["stop_loss_pct"])
+        recommendation.entry_price * (1 - strategy_payload["stop_loss_pct"])
     )
-    assert recommendation.expected_return == pytest.approx(trading_strategy.expected_return)
+    assert recommendation.expected_return == pytest.approx(strategy_payload["expected_return"])
     assert recommendation.risk_level == portfolio_risk.risk_level.value
 
     # Risk-adjusted confidence combines strategy win rate and risk score
     expected_confidence = (
-        trading_strategy.win_rate
+        strategy_payload["confidence_score"]
         + (1.0 - portfolio_risk.total_risk_score)
         + prediction_result.confidence
     ) / 3
     assert recommendation.confidence == pytest.approx(expected_confidence)
 
-    system.predictor.predict.assert_called_once_with("TEST")  # type: ignore[attr-defined]
-    system.risk_manager.analyze_portfolio_risk.assert_called_once()  # type: ignore[attr-defined]
-    portfolio_args = system.risk_manager.analyze_portfolio_risk.call_args[0]  # type: ignore[attr-defined]
-    assert portfolio_args[0]["positions"]["TEST"] == pytest.approx(data["Close"].iloc[-1])
-    assert portfolio_args[1]["TEST"] is data
+    system.predictor.predict.assert_called_once_with("TEST", data)  # type: ignore[attr-defined]
+    system.risk_manager.analyze_risk.assert_called_once()  # type: ignore[attr-defined]
+    risk_args = system.risk_manager.analyze_risk.call_args[0]  # type: ignore[attr-defined]
+    assert risk_args[0] == "TEST"
+    assert risk_args[1] is data
 
-    system.sentiment_analyzer.analyze_news_sentiment.assert_called_once()  # type: ignore[attr-defined]
-    system.strategy_generator.generate_momentum_strategy.assert_called_once_with("TEST", data)  # type: ignore[attr-defined]
+    system.sentiment_analyzer.analyze_sentiment.assert_called_once_with("TEST")  # type: ignore[attr-defined]
+    assert strategy_calls == [
+        ("TEST", data, prediction_payload, portfolio_risk, sentiment_payload)
+    ]
 
 @pytest.mark.asyncio
 async def test_analyze_single_stock_with_empty_strategy_returns_none(monkeypatch):
@@ -154,8 +261,16 @@ async def test_analyze_single_stock_with_empty_strategy_returns_none(monkeypatch
         symbol="TEST",
         metadata={},
     )
+    prediction_payload = {
+        "predicted_price": prediction_result.prediction,
+        "confidence": prediction_result.confidence,
+        "accuracy": prediction_result.accuracy,
+        "timestamp": prediction_result.timestamp,
+        "symbol": prediction_result.symbol,
+        "metadata": prediction_result.metadata,
+    }
     predictor = SimpleNamespace()
-    predictor.predict = MagicMock(return_value=prediction_result)  # type: ignore[attr-defined]
+    predictor.predict = MagicMock(return_value=prediction_payload)  # type: ignore[attr-defined]
     system.predictor = predictor  # type: ignore[assignment]
 
     portfolio_risk = PortfolioRisk(
@@ -168,17 +283,28 @@ async def test_analyze_single_stock_with_empty_strategy_returns_none(monkeypatch
         timestamp=datetime.now(),
     )
     risk_manager = SimpleNamespace()
-    risk_manager.analyze_portfolio_risk = MagicMock(return_value=portfolio_risk)  # type: ignore[attr-defined]
+    risk_manager.analyze_risk = MagicMock(return_value=portfolio_risk)  # type: ignore[attr-defined]
     system.risk_manager = risk_manager  # type: ignore[assignment]
 
     sentiment_analyzer = SimpleNamespace()
-    sentiment_analyzer.analyze_news_sentiment = MagicMock(return_value=0.25)  # type: ignore[attr-defined]
+    sentiment_payload = {"sentiment_score": 0.25}
+    sentiment_analyzer.analyze_news_sentiment = MagicMock(return_value=sentiment_payload)  # type: ignore[attr-defined]
+    sentiment_analyzer.analyze_sentiment = MagicMock(return_value=sentiment_payload)  # type: ignore[attr-defined]
     system.sentiment_analyzer = sentiment_analyzer  # type: ignore[assignment]
 
     # 空の辞書を返すようにモックを設定
-    strategy_generator = SimpleNamespace()
-    strategy_generator.generate_strategy = MagicMock(return_value={})  # type: ignore[attr-defined]
-    system.strategy_generator = strategy_generator  # type: ignore[assignment]
+    strategy_calls = []
+
+    def fake_generate_strategy_empty(self, *args, **kwargs):
+        strategy_calls.append(args)
+        return {}
+
+    monkeypatch.setattr(
+        full_auto_system.StrategyGeneratorAdapter,
+        "generate_strategy",
+        fake_generate_strategy_empty,
+        raising=False,
+    )
 
     data = pd.DataFrame(
         {"Close": [100.0, 102.0], "High": [101.0, 103.0], "Low": [99.0, 101.0]},
@@ -192,8 +318,81 @@ async def test_analyze_single_stock_with_empty_strategy_returns_none(monkeypatch
     assert recommendation is None
 
     # generate_strategy が呼び出されたことを確認
-    system.strategy_generator.generate_strategy.assert_called_once()  # type: ignore[attr-defined]
+    assert len(strategy_calls) == 1  # type: ignore[attr-defined]
 
+
+@pytest.mark.asyncio
+async def test_run_full_auto_analysis_prefers_highest_return_portfolio(monkeypatch):
+    """Regression test ensuring we keep the best performing portfolio."""
+
+    system = FullAutoInvestmentSystem()
+    system.settings.target_stocks = {"AAA": "AAA Corp", "BBB": "BBB Corp"}
+
+    base_data = pd.DataFrame(
+        {"Close": [100.0, 101.0, 102.0], "High": [101.0, 102.0, 103.0], "Low": [99.0, 100.0, 101.0]},
+        index=pd.date_range("2024-01-01", periods=3),
+    )
+
+    def fake_get_stock_data(symbol: str, period: str = "2y") -> pd.DataFrame:
+        data = base_data.copy()
+        data.attrs.setdefault("info", {})["longName"] = f"{symbol} Corp"
+        return data
+
+    monkeypatch.setattr(system.data_provider, "get_stock_data", fake_get_stock_data)
+
+    system.portfolio_sizes = [1, 2]
+
+    class DummyOptimizer:
+        def optimize_portfolio(self, profiles, target_size=20):
+            sorted_profiles = sorted(profiles, key=lambda p: p.symbol)
+            return sorted_profiles[:target_size]
+
+    system.optimizer = DummyOptimizer()
+
+    class DummyBacktester:
+        def __init__(self, data_provider):
+            self.data_provider = data_provider
+
+        def backtest_portfolio(self, selected_symbols):
+            return {"return_rate": 5.0 if len(selected_symbols) == 1 else 15.0}
+
+    monkeypatch.setattr(full_auto_system, "PortfolioBacktester", DummyBacktester)
+
+    recommendation = AutoRecommendation(
+        symbol="DUMMY",
+        company_name="Dummy Corp",
+        entry_price=100.0,
+        target_price=110.0,
+        stop_loss=95.0,
+        expected_return=0.1,
+        confidence=0.8,
+        risk_level="low",
+        buy_date=datetime.now(),
+        sell_date=datetime.now(),
+        reasoning="test",
+    )
+
+    async def fake_analyze(symbol: str, data: pd.DataFrame):
+        return AutoRecommendation(
+            symbol=symbol,
+            company_name=f"{symbol} Corp",
+            entry_price=recommendation.entry_price,
+            target_price=recommendation.target_price,
+            stop_loss=recommendation.stop_loss,
+            expected_return=recommendation.expected_return,
+            confidence=recommendation.confidence,
+            risk_level=recommendation.risk_level,
+            buy_date=recommendation.buy_date,
+            sell_date=recommendation.sell_date,
+            reasoning=recommendation.reasoning,
+        )
+
+    monkeypatch.setattr(system, "_analyze_single_stock", fake_analyze)
+
+    recommendations = await system.run_full_auto_analysis()
+
+    assert {rec.symbol for rec in recommendations} == {"AAA", "BBB"}
+    assert all(rec.company_name.endswith("Corp") for rec in recommendations)
 
 def test_perform_portfolio_risk_analysis_delegates_to_adapter():
     system = FullAutoInvestmentSystem()


### PR DESCRIPTION
## Summary
- restructure the automatic portfolio optimisation to return size-keyed candidates complete with backtest metrics and consume them safely when generating recommendations
- expand the full auto system unit suite with dependency stubs and a regression test that verifies the highest-return portfolio is selected

## Testing
- pytest tests/unit/test_full_auto_system.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dde279e354832198067b059e375d17