### PR TITLE
Improve graceful shutdown logging safety

### DIFF
--- a/tests/unit/test_utils/test_context_managers.py
+++ b/tests/unit/test_utils/test_context_managers.py
@@ -1,0 +1,46 @@
+import types
+import sys
+
+import pytest
+
+from utils import context_managers
+
+
+def test_final_cleanup_does_not_log_after_logging_shutdown(monkeypatch):
+    events = []
+    shutdown_marker = {"called": False}
+
+    monkeypatch.setattr(context_managers.signal, "signal", lambda *args, **kwargs: None)
+    monkeypatch.setattr(context_managers.atexit, "register", lambda func: None)
+
+    class FakeLogger:
+        def info(self, message):
+            if shutdown_marker["called"]:
+                raise AssertionError("Logging occurred after shutdown")
+            events.append(("info", message))
+
+        def warning(self, message):
+            events.append(("warning", message))
+
+        def error(self, message):
+            events.append(("error", message))
+
+    fake_logger = FakeLogger()
+    monkeypatch.setattr(context_managers, "logger", fake_logger)
+
+    def fake_logging_shutdown():
+        shutdown_marker["called"] = True
+        events.append(("logging.shutdown", None))
+
+    monkeypatch.setattr(context_managers.logging, "shutdown", fake_logging_shutdown)
+
+    fake_cache_module = types.SimpleNamespace(
+        shutdown_cache=lambda: events.append(("cache", "shutdown"))
+    )
+    monkeypatch.setitem(sys.modules, "utils.cache", fake_cache_module)
+
+    manager = context_managers.GracefulShutdownManager()
+    manager._final_cleanup()
+
+    assert shutdown_marker["called"] is True
+    assert ("logging.shutdown", None) in events


### PR DESCRIPTION
## Summary
- add logging helpers that fall back to stdout when handlers are unavailable during shutdown
- log completion messages before closing logging handlers to avoid ValueError emissions
- add a regression test covering `_final_cleanup` to guard against logging after shutdown

## Testing
- pytest tests/unit/test_utils/test_context_managers.py

------
https://chatgpt.com/codex/tasks/task_e_68dde4660e1483219df44ad1666cee4b