### PR TITLE
Add deterministic date range support for fallback ticker history

### DIFF
--- a/tests/unit/test_data/test_stock_data.py
+++ b/tests/unit/test_data/test_stock_data.py
@@ -242,3 +242,22 @@ def test_fallback_ticker_history_is_reproducible():
     history_second = second.history("1mo")
 
     pd.testing.assert_frame_equal(history_first, history_second)
+
+
+@pytest.mark.skipif(
+    not hasattr(stock_data_module, "_FallbackTicker"),
+    reason="Fallback ticker is not available when real yfinance is installed.",
+)
+def test_download_via_yfinance_with_dates_uses_fallback_history_range():
+    provider = StockDataProvider()
+    start = "2024-01-03"
+    end = "2024-01-12"
+
+    history, actual = provider._download_via_yfinance(
+        "FAKE", period=None, start=start, end=end
+    )
+
+    assert actual == "FAKE"
+    expected_index = pd.bdate_range(start=start, end=end)
+    assert list(history.index) == list(expected_index)
+    assert len(history) == len(expected_index)


### PR DESCRIPTION
## Summary
- extend the fallback ticker stub so history() accepts explicit date ranges and yields deterministic business-day OHLCV data
- add a regression test that exercises StockDataProvider._download_via_yfinance with start/end parameters when the fallback ticker is active

## Testing
- pytest tests/unit/test_data/test_stock_data.py


------
https://chatgpt.com/codex/tasks/task_e_68df58500fa483219aa1a21861b4f615