### PR TITLE
Ensure stock data endpoint returns fallback actual ticker

### DIFF
--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -174,7 +174,8 @@ async def get_stock_data(
         financial_metrics["symbol"] = validated_symbol
         if "company_name" in financial_metrics or company_name != lookup_symbol:
             financial_metrics["company_name"] = company_name
-        financial_metrics.setdefault("actual_ticker", actual_ticker_value)
+        if not financial_metrics.get("actual_ticker"):
+            financial_metrics["actual_ticker"] = actual_ticker_value
 
         current_price = float(technical_data["Close"].iloc[-1])
         price_change = 0.0


### PR DESCRIPTION
## Summary
- add regression test covering stock data endpoint fallback actual ticker behavior
- stub legacy_core MLStockPredictor in tests to satisfy router import
- update endpoint to replace falsy financial_metrics actual_ticker with fallback value from price data

## Testing
- pytest tests/test_api_endpoints.py::test_get_stock_data_includes_actual_ticker
- pytest tests/test_api_endpoints.py

------
https://chatgpt.com/codex/tasks/task_e_68df5b946a848321832cd73f8cfa81d3