### PR TITLE
Add models_refactored compatibility facade

### DIFF
--- a/models_refactored/__init__.py
+++ b/models_refactored/__init__.py
@@ -1,0 +1,24 @@
+"""Compatibility facade for the refactored models package.
+
+This module re-exports the public symbols from :mod:`models` lazily so that the
+refactored import paths used by the tests remain functional while the code base
+transitions to the new package structure.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+import models as _models
+
+__all__: List[str] = list(getattr(_models, "__all__", []))
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        return getattr(_models, name)
+    raise AttributeError(f"module 'models_refactored' has no attribute {name!r}")
+
+
+def __dir__() -> List[str]:
+    return sorted(set(__all__ + list(globals().keys())))

--- a/models_refactored/core/__init__.py
+++ b/models_refactored/core/__init__.py
@@ -1,0 +1,25 @@
+"""Refactored core compatibility layer."""
+
+from __future__ import annotations
+
+from models.core import (  # type: ignore F401
+    BaseStockPredictor,
+    DataProvider,
+    ModelConfiguration,
+    ModelManager,
+    PerformanceMetrics,
+    PredictionResult,
+    PredictorFactory,
+    StockPredictor,
+)
+
+__all__ = [
+    "BaseStockPredictor",
+    "DataProvider",
+    "ModelConfiguration",
+    "ModelManager",
+    "PerformanceMetrics",
+    "PredictionResult",
+    "PredictorFactory",
+    "StockPredictor",
+]

--- a/models_refactored/core/factory.py
+++ b/models_refactored/core/factory.py
@@ -1,0 +1,7 @@
+"""Compatibility wrapper for the refactored predictor factory."""
+
+from __future__ import annotations
+
+from models.core.factory import PredictorFactory  # type: ignore F401
+
+__all__ = ["PredictorFactory"]

--- a/models_refactored/core/interfaces.py
+++ b/models_refactored/core/interfaces.py
@@ -1,0 +1,27 @@
+"""Compatibility wrapper around :mod:`models.core.interfaces`."""
+
+from __future__ import annotations
+
+from models.core.interfaces import (  # type: ignore F401
+    BatchPredictionResult,
+    CacheProvider,
+    DataProvider,
+    ModelConfiguration,
+    ModelType,
+    PerformanceMetrics,
+    PredictionMode,
+    PredictionResult,
+    StockPredictor,
+)
+
+__all__ = [
+    "BatchPredictionResult",
+    "CacheProvider",
+    "DataProvider",
+    "ModelConfiguration",
+    "ModelType",
+    "PerformanceMetrics",
+    "PredictionMode",
+    "PredictionResult",
+    "StockPredictor",
+]

--- a/models_refactored/ensemble/__init__.py
+++ b/models_refactored/ensemble/__init__.py
@@ -1,0 +1,7 @@
+"""Ensemble predictor compatibility exports."""
+
+from __future__ import annotations
+
+from .ensemble_predictor import EnsemblePredictor, RefactoredEnsemblePredictor
+
+__all__ = ["EnsemblePredictor", "RefactoredEnsemblePredictor"]

--- a/models_refactored/ensemble/ensemble_predictor.py
+++ b/models_refactored/ensemble/ensemble_predictor.py
@@ -1,0 +1,10 @@
+"""Compatibility module for ensemble predictors."""
+
+from __future__ import annotations
+
+from models.ensemble.ensemble_predictor import (  # type: ignore F401
+    EnsemblePredictor,
+    RefactoredEnsemblePredictor,
+)
+
+__all__ = ["EnsemblePredictor", "RefactoredEnsemblePredictor"]

--- a/models_refactored/hybrid/__init__.py
+++ b/models_refactored/hybrid/__init__.py
@@ -1,0 +1,7 @@
+"""Hybrid predictor compatibility exports."""
+
+from __future__ import annotations
+
+from .hybrid_predictor import RefactoredHybridPredictor
+
+__all__ = ["RefactoredHybridPredictor"]

--- a/models_refactored/hybrid/hybrid_predictor.py
+++ b/models_refactored/hybrid/hybrid_predictor.py
@@ -1,0 +1,9 @@
+"""Refactored hybrid predictor compatibility module."""
+
+from __future__ import annotations
+
+from models.hybrid.refactored_hybrid_predictor import (  # type: ignore F401
+    RefactoredHybridPredictor,
+)
+
+__all__ = ["RefactoredHybridPredictor"]


### PR DESCRIPTION
## Summary
- add a models_refactored compatibility package that lazily re-exports the public API from models
- provide core, hybrid, and ensemble subpackages that forward to the existing refactored implementations

## Testing
- `pytest tests/integration/test_phase2.py tests/integration/test_refactored_system.py tests/unit/test_models/test_performance.py` *(fails: `PredictionResult.__init__()` requires `accuracy` and `symbol` arguments in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68df7e4c329083218d633af81f863378