### PR TITLE
Add Keltner Channel indicator utility

### DIFF
--- a/tests/unit/test_utils/test_technical_indicators.py
+++ b/tests/unit/test_utils/test_technical_indicators.py
@@ -1,0 +1,74 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+
+from utils.technical_indicators import calculate_keltner_channels
+
+
+pytest.importorskip("pandas")
+
+try:  # Ensure the real pandas Series implementation is available
+    pd.Series([0])
+except RuntimeError as exc:  # pragma: no cover - guard for stubbed pandas
+    pytest.skip(str(exc), allow_module_level=True)
+
+
+def test_calculate_keltner_channels_values():
+    high = pd.Series([10.0, 11.0, 12.0, 13.0])
+    low = pd.Series([9.0, 9.5, 10.0, 11.0])
+    close = pd.Series([9.5, 10.5, 11.5, 12.5])
+
+    channels = calculate_keltner_channels(
+        high=high, low=low, close=close, window=2, multiplier=1.5
+    )
+
+    expected_middle = pd.Series(
+        [9.5, 10.0555556, 10.7962964, 11.7098766]
+    )
+    expected_upper = pd.Series(
+        [np.nan, 11.9305556, 13.4212964, 14.7098766]
+    )
+    expected_lower = pd.Series(
+        [np.nan, 8.1805556, 8.1712964, 8.7098766]
+    )
+
+    pd.testing.assert_series_equal(
+        channels["Middle"],
+        expected_middle,
+        check_names=False,
+        check_exact=False,
+        atol=1e-6,
+    )
+    pd.testing.assert_series_equal(
+        channels["Upper"],
+        expected_upper,
+        check_names=False,
+        check_exact=False,
+        atol=1e-6,
+    )
+    pd.testing.assert_series_equal(
+        channels["Lower"],
+        expected_lower,
+        check_names=False,
+        check_exact=False,
+        atol=1e-6,
+    )
+
+
+def test_calculate_keltner_channels_error_fallback():
+    high = pd.Series(["a", "b"])
+    low = pd.Series(["c", "d"])
+    close = pd.Series([1.0, 2.0])
+
+    channels = calculate_keltner_channels(high, low, close)
+
+    expected = pd.DataFrame(
+        {
+            "Upper": close,
+            "Middle": close,
+            "Lower": close,
+        }
+    )
+
+    pd.testing.assert_frame_equal(channels, expected)

--- a/utils/technical_indicators.py
+++ b/utils/technical_indicators.py
@@ -132,3 +132,26 @@ def calculate_roc(prices: pd.Series, period: int = 12) -> pd.Series:
         return ((prices - prices.shift(period)) / prices.shift(period)) * 100
     except Exception:
         return pd.Series([0] * len(prices), index=prices.index)
+
+
+def calculate_keltner_channels(
+    high: pd.Series,
+    low: pd.Series,
+    close: pd.Series,
+    window: int = 20,
+    multiplier: float = 2.0,
+) -> pd.DataFrame:
+    """ケルトナーチャネル計算"""
+    try:
+        typical_price = (high + low + close) / 3
+        middle_band = typical_price.ewm(span=window, adjust=False).mean()
+        atr = calculate_atr(high, low, close, period=window)
+
+        upper_band = middle_band + (multiplier * atr)
+        lower_band = middle_band - (multiplier * atr)
+
+        return pd.DataFrame(
+            {"Upper": upper_band, "Middle": middle_band, "Lower": lower_band}
+        )
+    except Exception:
+        return pd.DataFrame({"Upper": close, "Middle": close, "Lower": close})


### PR DESCRIPTION
## Summary
- add a Keltner Channel calculator alongside the existing technical indicator helpers
- cover the new indicator with unit tests that validate numerical output and fallback handling

## Testing
- pytest tests/unit/test_utils/test_technical_indicators.py

------
https://chatgpt.com/codex/tasks/task_e_68e07f79230c8321911c9f04557930ec