### PR TITLE
Fix selective system entrypoint

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -392,7 +392,7 @@ def performance_monitor():
         import subprocess
 
         result = subprocess.run(
-            ["python", "performance_test_enhanced.py"], capture_output=True, text=True  # nosec B603, B607
+            ["python", "selective_system.py"], capture_output=True, text=True  # nosec B603, B607
         )
         print(result.stdout)
         if result.stderr:

--- a/selective_system.py
+++ b/selective_system.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""エントリーポイント: 厳選システムのクイック実行スクリプト."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict
+
+from ClStock.utils.logger_config import get_logger
+from ClStock.systems.resource_monitor import ResourceMonitor
+
+
+logger = get_logger(__name__)
+
+
+def _load_watchlist() -> List[Dict[str, str]]:
+    """サンプルの厳選銘柄リストを読み込む."""
+    sample_file = Path("data/watchlists/selective_watchlist.json")
+    if sample_file.exists():
+        try:
+            return json.loads(sample_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive logging
+            logger.warning("ウォッチリストのJSON読み込みに失敗しました: %s", exc)
+    # フォールバック: 静的に定義した推奨リスト
+    return [
+        {"symbol": "6758.T", "name": "ソニーG", "reason": "AI事業の収益拡大"},
+        {"symbol": "7203.T", "name": "トヨタ", "reason": "EV戦略の加速"},
+        {"symbol": "8306.T", "name": "三菱UFJ", "reason": "配当利回り安定"},
+    ]
+
+
+def main() -> None:
+    """厳選システムのサマリを出力する."""
+    logger.info("Selective system を起動します")
+
+    monitor = ResourceMonitor()
+    usage = monitor.get_system_usage()
+
+    print("\n=== Selective System ===")
+    print(f"起動時刻: {datetime.now():%Y-%m-%d %H:%M:%S}")
+    print(f"CPU使用率: {usage.cpu_percent:.1f}% / メモリ使用率: {usage.memory_percent:.1f}%")
+
+    watchlist = _load_watchlist()
+    print("\n推奨ウォッチリスト (上位3件)")
+    for idx, info in enumerate(watchlist, start=1):
+        print(f" {idx}. {info['symbol']} - {info['name']} ({info['reason']})")
+
+    print("\nシステム診断: 正常終了")
+
+
+if __name__ == "__main__":
+    main()

--- a/systems/service_registry.py
+++ b/systems/service_registry.py
@@ -119,7 +119,7 @@ class ServiceRegistry:
             ),
             "selective_system": ProcessInfo(
                 name="selective_system",
-                command="python performance_test_enhanced.py",
+                command="python selective_system.py",
                 working_dir=str(PROJECT_ROOT),
             ),
         }

--- a/tests/unit/test_systems/test_process_manager.py
+++ b/tests/unit/test_systems/test_process_manager.py
@@ -1,5 +1,6 @@
 "Tests for the process manager system."
 
+from pathlib import Path
 import pytest
 import threading
 from unittest.mock import Mock, patch, MagicMock
@@ -54,7 +55,20 @@ class TestProcessManager:
         assert optimized.command == "python ultra_optimized_system.py"
 
         selective = pm.processes["selective_system"]
-        assert selective.command == "python performance_test_enhanced.py"
+        assert selective.command == "python selective_system.py"
+
+    def test_selective_system_command_points_to_existing_file(self):
+        """The selective system should point to an existing executable."""
+        pm = ProcessManager()
+
+        selective = pm.processes["selective_system"]
+
+        # Extract the path to the executable/script from the command string.
+        command_parts = selective.command.split(maxsplit=1)
+        assert len(command_parts) == 2, "Command should include interpreter and script"
+
+        script_path = Path(command_parts[1])
+        assert script_path.exists(), f"Executable '{script_path}' should exist"
 
     def test_process_info_initialization(self):
         """Test ProcessInfo dataclass initialization."""


### PR DESCRIPTION
## Summary
- add a regression test asserting the selective system command targets a real executable
- point the selective system service and menu performance monitor to the new selective_system.py entrypoint
- provide a lightweight selective_system.py script that reports resource usage and a sample watchlist

## Testing
- pytest tests/unit/test_systems/test_process_manager.py -k selective

------
https://chatgpt.com/codex/tasks/task_e_68e127a01b3c83218fbd3e708027a13b