### PR TITLE
Align entry price range with current price

### DIFF
--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -55,11 +55,10 @@ def stock_recommendation_to_schema(stock_rec: StockRecommendation) -> StockRecom
         except:
             holding_period_days = 30  # エラー時デフォルト
 
-    # target_price (float) -> entry_price (object) の変換 (価格帯をどう設定するか)
-    # 簡易的に、target_priceを中央値として、±5%の範囲をmin/maxとする
-    price_range_pct = 0.05
-    entry_price_min = stock_rec.target_price * (1 - price_range_pct)
-    entry_price_max = stock_rec.target_price * (1 + price_range_pct)
+    # entry_price は current_price を中心に±3%の範囲を設定する
+    price_range_pct = 0.03
+    entry_price_min = stock_rec.current_price * (1 - price_range_pct)
+    entry_price_max = stock_rec.current_price * (1 + price_range_pct)
     entry_price = EntryPriceSchema(min=entry_price_min, max=entry_price_max)
 
     # profit_target_1, profit_target_2 (float) -> targets (List[object]) の変換


### PR DESCRIPTION
## Summary
- add a regression test confirming the recommendation endpoint reports entry_price bounds around the current price
- compute entry_price in stock_recommendation_to_schema using the current price with a ±3% band

## Testing
- pytest tests/test_api_endpoints.py::test_get_single_recommendation_entry_price_centered_on_current_price


------
https://chatgpt.com/codex/tasks/task_e_68e18af026d083218c8ac77df289916d