### PR TITLE
Handle weekend closed status for recommendations

### DIFF
--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -126,14 +126,17 @@ async def get_recommendations(
         current_time = datetime.now(ZoneInfo("Asia/Tokyo"))
         market_open_time = time(9, 0)
         market_close_time = time(15, 0)
+        is_weekend = current_time.weekday() >= 5
+        is_market_hours = (
+            market_open_time <= current_time.time() < market_close_time
+        )
 
         return RecommendationResponse(
             items=recommendations, # recommendations -> items に変更
             generated_at=current_time,
             market_status=(
                 "市場営業時間外"
-                if current_time.time() < market_open_time
-                or current_time.time() >= market_close_time
+                if is_weekend or not is_market_hours
                 else "市場営業中"
             ),
             top_n=top_n, # top_n フィールドも追加

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -302,6 +302,41 @@ def test_get_recommendations_returns_closed_after_15(monkeypatch):
     assert response.json()["market_status"] == "市場営業時間外"
 
 
+def test_get_recommendations_returns_closed_after_weekend(monkeypatch):
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls, tz=None):
+            assert tz == ZoneInfo("Asia/Tokyo")
+            return datetime(2024, 1, 6, 10, 0, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
+
+    monkeypatch.setattr("api.endpoints.datetime", DummyDateTime)
+
+    class DummyPredictor:
+        def __init__(self) -> None:
+            self.received_top_n = None
+
+        def get_top_recommendations(self, top_n):
+            self.received_top_n = top_n
+            return []
+
+    dummy_predictor = DummyPredictor()
+    monkeypatch.setattr("api.endpoints.MLStockPredictor", lambda: dummy_predictor)
+    monkeypatch.setattr("api.endpoints.verify_token", lambda token: None)
+
+    response = client.get(
+        "/recommendations",
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+    assert response.status_code == 200
+    assert dummy_predictor.received_top_n == 10
+    assert response.json()["market_status"] == "市場営業時間外"
+
+
 def test_health_endpoint_includes_security_headers():
     from app.main import app as main_app
 


### PR DESCRIPTION
## Summary
- add a regression test to ensure recommendations report the market as closed on weekend mornings
- update the recommendations endpoint to treat weekends as non-trading hours

## Testing
- pytest tests/test_api_endpoints.py::test_get_recommendations_returns_closed_after_weekend

------
https://chatgpt.com/codex/tasks/task_e_68e18af42cac8321a3af96e8a0f8bc5c