### PR TITLE
Handle missing yfinance gracefully in financial metrics

### DIFF
--- a/data/stock_data.py
+++ b/data/stock_data.py
@@ -255,38 +255,84 @@ self, data: pd.DataFrame) -> pd.DataFrame:
             "actual_ticker": None,
         }
 
+        if not YFINANCE_AVAILABLE or yf is None:
+            cache.set(cache_key, metrics, ttl=self.cache_ttl)
+            return metrics
+
         for ticker in self._ticker_formats(symbol):
             try:
-                ticker_obj = yf.Ticker(ticker)
-                info = getattr(ticker_obj, "info", {}) or {}
-                fast = getattr(ticker_obj, "fast_info", None)
-
-                metrics.update(
-                    {
-                        "market_cap": info.get("marketCap", metrics["market_cap"]),
-                        "pe_ratio": info.get("forwardPE") or info.get("trailingPE"),
-                        "dividend_yield": info.get("dividendYield"),
-                        "beta": info.get("beta", metrics["beta"]),
-                    }
-                )
-
-                if fast is not None:
-                    metrics["last_price"] = getattr(fast, "last_price", metrics["last_price"])
-                    metrics["previous_close"] = getattr(
-                        fast, "previous_close", metrics["previous_close"]
-                    )
-                    metrics["ten_day_average_volume"] = getattr(
-                        fast, "ten_day_average_volume", metrics["ten_day_average_volume"]
-                    )
-
-                metrics["actual_ticker"] = ticker
-                break
+                if self._fetch_financial_metrics_via_yfinance(ticker, metrics):
+                    break
             except Exception as exc:  # pragma: no cover - defensive
                 logger.debug("Failed to retrieve financial metrics for %s via %s: %s", symbol, ticker, exc)
                 continue
 
         cache.set(cache_key, metrics, ttl=self.cache_ttl)
         return metrics
+
+    def _fetch_financial_metrics_via_yfinance(
+        self, ticker: str, metrics: Dict[str, Optional[float]]
+    ) -> bool:
+        """Populate *metrics* using ``yfinance`` for the given *ticker*.
+
+        The helper guards against missing dependencies or partial responses and
+        returns ``True`` only when some data was successfully retrieved.
+        """
+
+        if not YFINANCE_AVAILABLE or yf is None:
+            return False
+
+        try:
+            ticker_obj = yf.Ticker(ticker)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            logger.debug("Failed to instantiate yfinance ticker %s: %s", ticker, exc)
+            return False
+
+        info = getattr(ticker_obj, "info", {}) or {}
+        fast = getattr(ticker_obj, "fast_info", None)
+
+        has_data = False
+
+        market_cap = info.get("marketCap")
+        if market_cap is not None:
+            metrics["market_cap"] = market_cap
+            has_data = True
+
+        pe_ratio = info.get("forwardPE") or info.get("trailingPE")
+        if pe_ratio is not None:
+            metrics["pe_ratio"] = pe_ratio
+            has_data = True
+
+        dividend_yield = info.get("dividendYield")
+        if dividend_yield is not None:
+            metrics["dividend_yield"] = dividend_yield
+            has_data = True
+
+        beta = info.get("beta")
+        if beta is not None:
+            metrics["beta"] = beta
+            has_data = True
+
+        if fast is not None:
+            last_price = getattr(fast, "last_price", None)
+            if last_price is not None:
+                metrics["last_price"] = last_price
+                has_data = True
+
+            previous_close = getattr(fast, "previous_close", None)
+            if previous_close is not None:
+                metrics["previous_close"] = previous_close
+                has_data = True
+
+            ten_day_average_volume = getattr(fast, "ten_day_average_volume", None)
+            if ten_day_average_volume is not None:
+                metrics["ten_day_average_volume"] = ten_day_average_volume
+                has_data = True
+
+        if has_data:
+            metrics["actual_ticker"] = ticker
+
+        return has_data
 
     # ------------------------------------------------------------------
     # Helper methods

--- a/tests/data/test_stock_data_provider.py
+++ b/tests/data/test_stock_data_provider.py
@@ -1,0 +1,108 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "data" / "stock_data.py"
+
+spec = importlib.util.spec_from_file_location("stock_data_under_test", MODULE_PATH)
+stock_data = importlib.util.module_from_spec(spec)
+sys.modules["stock_data_under_test"] = stock_data
+assert spec.loader is not None
+spec.loader.exec_module(stock_data)
+
+StockDataProvider = stock_data.StockDataProvider
+from utils.cache import clear_cache, get_cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_cache()
+    yield
+    clear_cache()
+
+
+def test_get_financial_metrics_returns_defaults_when_yfinance_missing(monkeypatch):
+    monkeypatch.setattr(stock_data, "YFINANCE_AVAILABLE", False, raising=False)
+    monkeypatch.setattr(stock_data, "yf", None, raising=False)
+
+    provider = StockDataProvider()
+    provider.jp_stock_codes = {"TEST": "Test Corp"}
+
+    call_count = {"count": 0}
+
+    def fail_helper(self, ticker, metrics):
+        call_count["count"] += 1
+        raise AssertionError("helper should not be invoked when yfinance is unavailable")
+
+    monkeypatch.setattr(
+        StockDataProvider,
+        "_fetch_financial_metrics_via_yfinance",
+        fail_helper,
+        raising=False,
+    )
+
+    metrics = provider.get_financial_metrics("TEST")
+
+    assert metrics["symbol"] == "TEST"
+    assert metrics["company_name"] == "Test Corp"
+    assert metrics["market_cap"] is None
+    assert metrics["pe_ratio"] is None
+    assert metrics["actual_ticker"] is None
+    assert call_count["count"] == 0
+
+    cache_key = "financial::TEST"
+    cached = get_cache().get(cache_key)
+    assert cached == metrics
+
+    metrics_again = provider.get_financial_metrics("TEST")
+    assert metrics_again == metrics
+
+
+def test_get_financial_metrics_uses_yfinance_helper_when_available(monkeypatch):
+    monkeypatch.setattr(stock_data, "YFINANCE_AVAILABLE", True, raising=False)
+
+    provider = StockDataProvider()
+    provider.jp_stock_codes = {"TEST": "Test Corp"}
+
+    calls = []
+
+    def fake_helper(self, ticker, metrics):
+        calls.append(ticker)
+        metrics.update(
+            {
+                "market_cap": 123,
+                "pe_ratio": 45.6,
+                "dividend_yield": 0.01,
+                "beta": 1.2,
+                "last_price": 100.5,
+                "previous_close": 99.5,
+                "ten_day_average_volume": 1000,
+                "actual_ticker": ticker,
+            }
+        )
+        return True
+
+    monkeypatch.setattr(
+        StockDataProvider,
+        "_fetch_financial_metrics_via_yfinance",
+        fake_helper,
+        raising=False,
+    )
+
+    metrics = provider.get_financial_metrics("TEST")
+
+    assert calls == ["TEST"]
+    assert metrics["market_cap"] == 123
+    assert metrics["pe_ratio"] == 45.6
+    assert metrics["dividend_yield"] == 0.01
+    assert metrics["beta"] == 1.2
+    assert metrics["last_price"] == 100.5
+    assert metrics["previous_close"] == 99.5
+    assert metrics["ten_day_average_volume"] == 1000
+    assert metrics["actual_ticker"] == "TEST"
+
+    metrics_again = provider.get_financial_metrics("TEST")
+    assert metrics_again == metrics
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary
- ensure get_financial_metrics returns cached defaults when yfinance is unavailable
- refactor yfinance data gathering into a helper with defensive error handling
- add targeted tests covering missing and available yfinance scenarios

## Testing
- pytest tests/data/test_stock_data_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68e1cf6eed808321a3fe0d0cec3cd882