### PR TITLE
Refactor prediction dashboard data flow

### DIFF
--- a/tests/test_advanced_models.py
+++ b/tests/test_advanced_models.py
@@ -8,7 +8,10 @@ import pandas as pd
 from unittest.mock import Mock, patch, MagicMock
 from datetime import datetime
 
-from models.advanced.prediction_dashboard import PredictionDashboard
+from models.advanced.prediction_dashboard import (
+    PredictionDashboard,
+    VisualizationData,
+)
 from models.advanced.market_sentiment_analyzer import MarketSentimentAnalyzer
 from models.core.interfaces import (
     ModelConfiguration,
@@ -23,6 +26,18 @@ class TestPredictionDashboard:
     def setup_method(self):
         """各テストメソッドの前に実行"""
         self.dashboard = PredictionDashboard()
+
+    def _extract_text(self, component):
+        if component is None:
+            return ""
+        if isinstance(component, str):
+            return component
+        children = getattr(component, "children", None)
+        if children is None:
+            return ""
+        if isinstance(children, (list, tuple)):
+            return "".join(self._extract_text(child) for child in children)
+        return self._extract_text(children)
 
     def test_dashboard_initialization(self):
         """ダッシュボード初期化のテスト"""
@@ -72,6 +87,103 @@ class TestPredictionDashboard:
         except Exception:
             # 例外が発生してもテストは通る
             pass
+
+    def test_generate_live_components_with_services(self):
+        """依存サービスからのデータでコンポーネントを構築できることを確認"""
+
+        dates = pd.date_range("2024-01-01", periods=5, freq="D")
+        historical = pd.DataFrame(
+            {
+                "Open": [100, 101, 102, 103, 104],
+                "High": [102, 103, 104, 105, 106],
+                "Low": [99, 100, 101, 102, 103],
+                "Close": [101, 102, 103, 104, 105],
+                "Volume": [1000, 1100, 1050, 1200, 1300],
+            },
+            index=dates,
+        )
+        predictions = [
+            {
+                "timestamp": dates[-1] + pd.Timedelta(days=1),
+                "prediction": 106.5,
+                "confidence": 0.9,
+                "accuracy": 92.0,
+                "mode": "test",
+                "prediction_time": 0.2,
+            }
+        ]
+        metrics = {"rmse": 0.25, "mape": 0.05}
+        base_sentiment = {
+            "current_sentiment": {"score": 0.3, "momentum": 0.1},
+            "sources_breakdown": {"news": 0.2, "social": -0.1},
+        }
+
+        visualization_data = VisualizationData(
+            symbol="6758.T",
+            predictions=predictions,
+            historical_data=historical,
+            sentiment_data=base_sentiment,
+            performance_metrics=metrics,
+            timestamp=datetime.now(),
+        )
+
+        prediction_service = MagicMock()
+        prediction_service.get_visualization_data.return_value = visualization_data
+
+        sentiment_service = MagicMock()
+        service_sentiment = {
+            "current_sentiment": {"score": 0.5, "momentum": 0.2},
+            "sources_breakdown": {"news": 0.4, "social": 0.1},
+        }
+        sentiment_service.get_sentiment.return_value = service_sentiment
+
+        dashboard = PredictionDashboard(
+            prediction_service=prediction_service,
+            sentiment_service=sentiment_service,
+        )
+
+        prediction_fig, sentiment_fig, metrics_component = dashboard.generate_live_components(
+            "6758.T"
+        )
+
+        assert prediction_service.get_visualization_data.called
+        assert sentiment_service.get_sentiment.called
+
+        # 予測チャートに予測値が含まれているか確認
+        pred_trace_values = [
+            list(getattr(trace, "y", []))
+            for trace in prediction_fig.data
+            if getattr(trace, "name", "") == "予測価格"
+        ]
+        assert pred_trace_values, "予測価格のトレースが存在しません"
+        assert predictions[0]["prediction"] in pred_trace_values[0]
+
+        # センチメントチャートがサービスの値を反映しているか確認
+        assert sentiment_fig.data[0]["value"] == service_sentiment["current_sentiment"]["score"]
+
+        # メトリクス表示にRMSEが含まれているか確認
+        metrics_text = self._extract_text(metrics_component)
+        assert "rmse" in metrics_text
+        assert "0.25" in metrics_text
+
+    def test_generate_live_components_with_retry_on_failure(self):
+        """データ取得エラー時にリトライとエラーメッセージが機能することを確認"""
+
+        prediction_service = MagicMock()
+        prediction_service.get_visualization_data.side_effect = Exception("service down")
+
+        dashboard = PredictionDashboard(prediction_service=prediction_service)
+
+        prediction_fig, sentiment_fig, metrics_component = dashboard.generate_live_components(
+            "6758.T"
+        )
+
+        # リトライが行われ、最終的にエラーが表示されることを確認
+        assert prediction_service.get_visualization_data.call_count == 2
+        error_text = self._extract_text(metrics_component)
+        assert "service down" in error_text
+        assert prediction_fig.layout.annotations[0]["text"].startswith("データ取得に失敗")
+        assert sentiment_fig.layout.annotations[0]["text"].startswith("センチメント取得に失敗")
 
 
 class TestMarketSentimentAnalyzer:


### PR DESCRIPTION
## Summary
- inject prediction and sentiment services into PredictionDashboard and store retry configuration
- build Dash callback outputs from real visualization data with retries and error handling instead of random placeholders
- expand tests to validate successful data rendering and failure scenarios using the new service-driven pipeline

## Testing
- pytest tests/test_advanced_models.py::TestPredictionDashboard::test_generate_live_components_with_services
- pytest tests/test_advanced_models.py::TestPredictionDashboard::test_generate_live_components_with_retry_on_failure

------
https://chatgpt.com/codex/tasks/task_e_68e216faf1b883219af4d398e3b9b971