### PR TITLE
Ensure reinforcement trading system validates market data provider

### DIFF
--- a/systems/reinforcement_trading_system.py
+++ b/systems/reinforcement_trading_system.py
@@ -1,12 +1,16 @@
 """強化学習による取引戦略の最適化"""
-import numpy as np
-import pandas as pd
+from __future__ import annotations
+
+import logging
+from typing import Optional, Protocol, runtime_checkable
+
 import gym
 from gym import spaces
+import numpy as np
+import pandas as pd
 from stable_baselines3 import PPO
-from stable_baselines3.common.vec_env import DummyVecEnv
 from stable_baselines3.common.callbacks import BaseCallback
-import logging
+from stable_baselines3.common.vec_env import DummyVecEnv
 
 logger = logging.getLogger(__name__)
 
@@ -118,60 +122,104 @@ class TradingCallback(BaseCallback):
         # 各ステップで実行する処理
         return True
 
+@runtime_checkable
+class MarketDataProviderProtocol(Protocol):
+    """強化学習システムが利用する市場データプロバイダーのプロトコル。"""
+
+    def get_stock_data(self, symbol: str, period: str) -> pd.DataFrame:
+        """指定した銘柄・期間の株価データを返す。"""
+
+
 class ReinforcementTradingSystem:
-    """強化学習による取引戦略最適化システム"""
-    
-    def __init__(self, data_provider=None):
-        self.data_provider = data_provider
+    """強化学習による取引戦略最適化システム。
+
+    Notes
+    -----
+    ``data_provider`` には :class:`MarketDataProviderProtocol` を満たすオブジェクトを渡す必要がある。
+    ``get_stock_data`` は以下の条件を満たす :class:`pandas.DataFrame` を返却しなければならない。
+
+    * インデックスは昇順にソートされた :class:`pandas.DatetimeIndex`
+    * 必須カラム: ``Open``, ``High``, ``Low``, ``Close``, ``Volume``
+    * 実市場から取得した数値が格納されていること（テストでは同形式のスタブで代用可）
+    """
+
+    REQUIRED_COLUMNS = ("Open", "High", "Low", "Close", "Volume")
+
+    def __init__(self, data_provider: Optional[MarketDataProviderProtocol] = None):
+        self.data_provider: Optional[MarketDataProviderProtocol] = data_provider
         self.model = None
         self.env = None
-        
-    def prepare_data(self, symbol, period='1y'):
-        """取引環境用データの準備"""
-        if self.data_provider:
-            stock_data = self.data_provider.get_stock_data(symbol, period)
-        else:
-            # ダミーデータの作成（デバッグ用）
-            dates = pd.date_range(start='2023-01-01', periods=252, freq='D')  # 1年分のデータ
-            close_prices = np.random.normal(100, 10, size=len(dates))  # ダミー株価
-            stock_data = pd.DataFrame({
-                'Date': dates,
-                'Close': close_prices,
-                'Open': close_prices * np.random.uniform(0.99, 1.01, size=len(dates)),
-                'High': close_prices * np.random.uniform(1.0, 1.05, size=len(dates)),
-                'Low': close_prices * np.random.uniform(0.95, 1.0, size=len(dates)),
-                'Volume': np.random.randint(100000, 1000000, size=len(dates))
-            })
-            stock_data.set_index('Date', inplace=True)
-            
+
+    def prepare_data(self, symbol: str, period: str = "1y") -> pd.DataFrame:
+        """取引環境用データの準備。
+
+        Parameters
+        ----------
+        symbol:
+            取得対象の銘柄コード。
+        period:
+            データ取得対象期間（例: ``"1y"`` や ``"6mo"`` など）。
+
+        Returns
+        -------
+        pandas.DataFrame
+            強化学習環境が利用可能な株価データ。
+
+        Raises
+        ------
+        ValueError
+            ``data_provider`` が未設定、もしくは必須条件を満たさないデータが返却された場合。
+        """
+
+        if self.data_provider is None:
+            raise ValueError(
+                "data_provider が設定されていません。設定ファイルで市場データの取得先を指定するか、"
+                "ReinforcementTradingSystem に対応した data_provider を注入してください。"
+            )
+
+        stock_data = self.data_provider.get_stock_data(symbol, period)
+
+        if not isinstance(stock_data, pd.DataFrame):
+            raise ValueError("data_provider.get_stock_data は pandas.DataFrame を返却する必要があります。")
+
+        if not isinstance(stock_data.index, pd.DatetimeIndex):
+            raise ValueError("株価データのインデックスは pandas.DatetimeIndex でなければなりません。")
+
+        missing_columns = [col for col in self.REQUIRED_COLUMNS if col not in stock_data.columns]
+        if missing_columns:
+            raise ValueError(f"株価データに必須カラムが不足しています: {', '.join(missing_columns)}")
+
+        if not stock_data.index.is_monotonic_increasing:
+            stock_data = stock_data.sort_index()
+
         return stock_data
         
-    def train_model(self, symbol, period='1y', timesteps=10000):
+    def train_model(self, symbol: str, period: str = '1y', timesteps: int = 10000) -> None:
         """モデルの訓練"""
         # 取引環境の作成
         stock_data = self.prepare_data(symbol, period)
         self.env = DummyVecEnv([lambda: TradingEnv(stock_data)])
-        
+
         # PPOモデルの作成と訓練
         self.model = PPO('MlpPolicy', self.env, verbose=1, tensorboard_log="./ppo_trading_tensorboard/")
         self.model.learn(total_timesteps=timesteps, callback=TradingCallback())
-        
+
         logger.info(f"強化学習モデルの訓練完了: {symbol}")
-        
-    def predict_action(self, observation):
+
+    def predict_action(self, observation) -> int:
         """行動の予測"""
         if self.model is None:
             raise ValueError("モデルが訓練されていません")
-            
+
         action, _states = self.model.predict(observation)
         return action
-        
-    def evaluate_strategy(self, symbol, period='6m'):
+
+    def evaluate_strategy(self, symbol: str, period: str = '6m') -> float:
         """取引戦略の評価"""
         stock_data = self.prepare_data(symbol, period)
         test_env = TradingEnv(stock_data)
         obs = test_env.reset()
-        
+
         total_reward = 0
         done = False
         
@@ -179,6 +227,6 @@ class ReinforcementTradingSystem:
             action = self.predict_action(obs)
             obs, reward, done, info = test_env.step(action)
             total_reward += reward
-            
+
         logger.info(f"取引戦略評価完了: {symbol}, 総報酬: {total_reward}")
         return total_reward

--- a/tests/systems/test_reinforcement_trading_system.py
+++ b/tests/systems/test_reinforcement_trading_system.py
@@ -1,0 +1,126 @@
+import sys
+import types
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def _install_rl_stubs() -> None:
+    """テスト環境用に強化学習関連のスタブモジュールを登録する。"""
+
+    if "gym" not in sys.modules:
+        gym_stub = types.ModuleType("gym")
+
+        class _DummyEnv:
+            pass
+
+        gym_stub.Env = _DummyEnv
+        spaces_stub = types.ModuleType("gym.spaces")
+
+        class _DummyDiscrete:
+            def __init__(self, n):
+                self.n = n
+
+        class _DummyBox:
+            def __init__(self, low, high, shape, dtype=None):
+                self.low = low
+                self.high = high
+                self.shape = shape
+                self.dtype = dtype
+
+        spaces_stub.Discrete = _DummyDiscrete
+        spaces_stub.Box = _DummyBox
+        gym_stub.spaces = spaces_stub
+        sys.modules["gym"] = gym_stub
+        sys.modules["gym.spaces"] = spaces_stub
+
+    if "stable_baselines3" not in sys.modules:
+        sb3_stub = types.ModuleType("stable_baselines3")
+
+        class _DummyPPO:
+            def __init__(self, *_, **__):
+                pass
+
+            def learn(self, *_, **__):
+                return self
+
+            def predict(self, observation):
+                return 0, None
+
+        sb3_stub.PPO = _DummyPPO
+
+        common_stub = types.ModuleType("stable_baselines3.common")
+        vec_env_stub = types.ModuleType("stable_baselines3.common.vec_env")
+
+        class _DummyVecEnv:
+            def __init__(self, env_fns):
+                self.envs = [fn() for fn in env_fns]
+
+            def reset(self):
+                return self.envs[0].reset()
+
+        vec_env_stub.DummyVecEnv = _DummyVecEnv
+
+        callbacks_stub = types.ModuleType("stable_baselines3.common.callbacks")
+
+        class _DummyBaseCallback:
+            def __init__(self, *_, **__):
+                pass
+
+        callbacks_stub.BaseCallback = _DummyBaseCallback
+
+        sys.modules["stable_baselines3"] = sb3_stub
+        sys.modules["stable_baselines3.common"] = common_stub
+        sys.modules["stable_baselines3.common.vec_env"] = vec_env_stub
+        sys.modules["stable_baselines3.common.callbacks"] = callbacks_stub
+
+
+_install_rl_stubs()
+
+from systems.reinforcement_trading_system import ReinforcementTradingSystem
+
+
+class StubMarketDataProvider:
+    """テスト用の市場データプロバイダー。"""
+
+    def __init__(self):
+        index = pd.date_range(end="2024-01-10", periods=10, freq="B")
+        self._data = pd.DataFrame(
+            {
+                "Open": np.linspace(100, 109, len(index)),
+                "High": np.linspace(101, 110, len(index)),
+                "Low": np.linspace(99, 108, len(index)),
+                "Close": np.linspace(100.5, 109.5, len(index)),
+                "Volume": np.full(len(index), 1000, dtype=float),
+            },
+            index=index,
+        )
+        self.calls = []
+
+    def get_stock_data(self, symbol: str, period: str) -> pd.DataFrame:
+        self.calls.append((symbol, period))
+        return self._data.copy()
+
+
+def test_prepare_data_requires_provider():
+    system = ReinforcementTradingSystem()
+
+    with pytest.raises(ValueError) as excinfo:
+        system.prepare_data("TEST")
+
+    assert "data_provider" in str(excinfo.value)
+
+
+def test_prepare_data_returns_provider_data_without_dummy_usage():
+    provider = StubMarketDataProvider()
+    system = ReinforcementTradingSystem(data_provider=provider)
+
+    data = system.prepare_data("REAL", period="1mo")
+
+    # プロバイダーが呼び出されたことを検証
+    assert provider.calls == [("REAL", "1mo")]
+
+    # 返されたデータが期待通りであることを検証
+    pd.testing.assert_index_equal(data.index, provider._data.index)
+    pd.testing.assert_frame_equal(data, provider._data)


### PR DESCRIPTION
## Summary
- document and enforce the market data provider interface for the reinforcement trading system
- validate returned market data and remove fallback dummy data usage
- add dedicated tests with reinforcement learning stubs and update existing deep model tests to inject a provider

## Testing
- pytest tests/systems/test_reinforcement_trading_system.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e216fb75d48321bfa7c6942c048171