### PR TITLE
Implement lightweight portfolio backtesting metrics

### DIFF
--- a/tests/unit/test_trading/test_tse_backtester.py
+++ b/tests/unit/test_trading/test_tse_backtester.py
@@ -1,0 +1,48 @@
+import pandas as pd
+import pytest
+
+from trading.tse.backtester import PortfolioBacktester
+
+
+class StubProvider:
+    def __init__(self, frames):
+        self.frames = frames
+        self.calls = []
+
+    def get_multiple_stocks(self, symbols, period="1y"):
+        self.calls.append((tuple(symbols), period))
+        return {symbol: self.frames[symbol] for symbol in symbols if symbol in self.frames}
+
+
+@pytest.fixture
+def sample_frames():
+    index = pd.date_range("2020-01-01", periods=4, freq="D")
+    return {
+        "AAA": pd.DataFrame({"Close": [100, 110, 105, 120]}, index=index),
+        "BBB": pd.DataFrame({"Close": [200, 190, 195, 210]}, index=index),
+    }
+
+
+def test_backtest_portfolio_computes_metrics(sample_frames):
+    provider = StubProvider(sample_frames)
+    backtester = PortfolioBacktester(provider)
+
+    result = backtester.backtest_portfolio(["AAA", "BBB"], period="6mo")
+
+    assert provider.calls == [(("AAA", "BBB"), "6mo")]
+    assert result["symbols"] == ["AAA", "BBB"]
+    assert result["period"] == "6mo"
+    assert result["observations"] == 3
+    assert pytest.approx(result["return_rate"], rel=1e-3) == 12.675
+    assert pytest.approx(result["total_return"], rel=1e-3) == 0.12675
+    assert pytest.approx(result["volatility"], rel=1e-3) == 0.05019
+    assert pytest.approx(result["sharpe_ratio"], rel=1e-3) == 13.2123
+    assert pytest.approx(result["max_drawdown"], rel=1e-3) == -0.009567
+
+
+def test_backtest_portfolio_requires_prices(sample_frames):
+    empty_provider = StubProvider({symbol: df.iloc[:1] for symbol, df in sample_frames.items()})
+    backtester = PortfolioBacktester(empty_provider)
+
+    with pytest.raises(ValueError):
+        backtester.backtest_portfolio(["AAA", "BBB"])

--- a/trading/tse/backtester.py
+++ b/trading/tse/backtester.py
@@ -1,22 +1,102 @@
 """Portfolio backtesting module for ClStock."""
 
-from typing import Dict, List, Any
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence
+
+import pandas as pd
+
 from data.stock_data import StockDataProvider
 
 
 class PortfolioBacktester:
-    """Portfolio backtester class."""
+    """Perform a lightweight equal-weight portfolio backtest."""
+
+    _CLOSE_CANDIDATES: Sequence[str] = ("Close", "Adj Close", "close", "adj_close")
 
     def __init__(self, data_provider: StockDataProvider):
         self.data_provider = data_provider
 
-    def backtest_portfolio(self, symbols: List[str]) -> Dict[str, Any]:
-        """Backtest portfolio with given symbols."""
-        # ダミーのバックテストロジック
+    def backtest_portfolio(
+        self, symbols: Sequence[str], period: str = "1y"
+    ) -> Dict[str, Any]:
+        """Backtest *symbols* for the specified *period*.
+
+        The implementation intentionally keeps the calculation lightweight so it
+        can run in constrained CI environments while still returning useful
+        summary statistics for the portfolio.
+        """
+
+        if not symbols:
+            raise ValueError("At least one symbol must be provided for backtesting")
+
+        history = self.data_provider.get_multiple_stocks(symbols, period=period)
+
+        returns: List[pd.Series] = []
+        used_symbols: List[str] = []
+
+        for symbol in symbols:
+            frame = history.get(symbol)
+            if frame is None or frame.empty:
+                continue
+
+            close = self._extract_close_prices(frame)
+            if close is None or close.shape[0] < 2:
+                continue
+
+            close = close.sort_index()
+            daily_returns = close.pct_change().dropna()
+            if daily_returns.empty:
+                continue
+
+            daily_returns.name = symbol
+            returns.append(daily_returns)
+            used_symbols.append(symbol)
+
+        if not returns:
+            raise ValueError("Price history is unavailable for the requested symbols")
+
+        aligned = pd.concat(returns, axis=1, join="inner")
+        if aligned.empty:
+            raise ValueError("No overlapping price history to compute portfolio returns")
+
+        aligned = aligned.sort_index()
+        portfolio_returns = aligned.mean(axis=1)
+        if portfolio_returns.empty:
+            raise ValueError("Not enough return observations to compute statistics")
+
+        cumulative = (1 + portfolio_returns).cumprod()
+        total_return = cumulative.iloc[-1] - 1
+        max_drawdown = (cumulative / cumulative.cummax() - 1).min()
+
+        volatility = float(portfolio_returns.std(ddof=0))
+        avg_return = float(portfolio_returns.mean())
+        sharpe_ratio = 0.0
+        if volatility > 0:
+            sharpe_ratio = (avg_return / volatility) * (252 ** 0.5)
+
         return {
-            "return_rate": 10.0,
-            "sharpe_ratio": 1.2,
-            "max_drawdown": -5.0,
-            "total_return": 15.0,
-            "volatility": 8.0
+            "symbols": used_symbols,
+            "period": period,
+            "observations": int(portfolio_returns.shape[0]),
+            "return_rate": float(total_return * 100),
+            "total_return": float(total_return),
+            "volatility": volatility,
+            "sharpe_ratio": float(sharpe_ratio),
+            "max_drawdown": float(max_drawdown),
         }
+
+    def _extract_close_prices(self, frame: pd.DataFrame) -> pd.Series | None:
+        """Return a price series from *frame* if available."""
+
+        for candidate in self._CLOSE_CANDIDATES:
+            if candidate in frame.columns:
+                series = pd.to_numeric(frame[candidate], errors="coerce")
+                series = series.dropna()
+                return series
+
+        if frame.shape[1] == 1:
+            series = pd.to_numeric(frame.iloc[:, 0], errors="coerce")
+            return series.dropna()
+
+        return None


### PR DESCRIPTION
## Summary
- replace the placeholder portfolio backtester logic with real metric calculations
- add targeted unit tests covering the portfolio backtester happy path and error handling

## Testing
- pytest tests/unit/test_trading/test_tse_backtester.py

------
https://chatgpt.com/codex/tasks/task_e_68e3034a43b083219f610a7f0cb302f6