### PR TITLE
Restore company_name field in recommendation responses

### DIFF
--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -94,7 +94,7 @@ def stock_recommendation_to_schema(
     return StockRecommendationSchema(
         rank=stock_rec.rank,
         symbol=stock_rec.symbol,
-        name=stock_rec.company_name,  # company_name -> name
+        company_name=stock_rec.company_name,
         sector=None,  # デフォルト
         score=stock_rec.score,
         action=action,

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 
 class EntryPriceSchema(BaseModel):
@@ -35,7 +35,10 @@ class StockRecommendationSchema(BaseModel):
 
     rank: int
     symbol: str
-    name: str  # company_name -> name に変更
+    company_name: str = Field(
+        ...,
+        validation_alias=AliasChoices("company_name", "name"),
+    )
     sector: Optional[str] = None  # 追加
     score: float
     action: str  # 追加
@@ -56,7 +59,7 @@ class StockRecommendationSchema(BaseModel):
     # current_price は一旦維持
     current_price: Optional[float] = None
 
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
 class RecommendationResponse(BaseModel):

--- a/tests/unit/test_api_schemas.py
+++ b/tests/unit/test_api_schemas.py
@@ -1,0 +1,31 @@
+from api.schemas import EntryPriceSchema, StockRecommendationSchema, TargetSchema
+
+
+def test_stock_recommendation_schema_includes_company_name_key():
+    schema = StockRecommendationSchema(
+        rank=1,
+        symbol="7203",
+        company_name="Test Corp",
+        sector=None,
+        score=85.0,
+        action="buy",
+        action_text="Buy dips",
+        entry_condition="Pullback",
+        entry_price=EntryPriceSchema(min=98.0, max=102.0),
+        stop_loss=95.0,
+        targets=[
+            TargetSchema(label="base", price=110.0),
+            TargetSchema(label="stretch", price=120.0),
+        ],
+        holding_period_days=30,
+        confidence=0.75,
+        rationale="Strong fundamentals",
+        notes=None,
+        risk_level="medium",
+        chart_refs=None,
+        current_price=100.0,
+    )
+
+    dumped = schema.model_dump()
+    assert dumped["company_name"] == "Test Corp"
+    assert "name" not in dumped


### PR DESCRIPTION
## Summary
- reintroduce the `company_name` field on the stock recommendation schema while still accepting the previous `name` alias
- update the recommendation endpoint adapter to populate the restored field
- add a unit test that asserts the serialized schema exposes `company_name`

## Testing
- pytest tests/unit/test_api_schemas.py *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68e4335f94dc83219dcdaf13f8496ac8