### PR TITLE
Add pagination parameter validator and tests

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -12,6 +12,7 @@ from utils.validators import (
     validate_date_range,
     validate_email,
     validate_numeric_range,
+    validate_pagination_params,
     validate_period,
     validate_stock_symbol,
     validate_symbols_list,
@@ -316,3 +317,40 @@ class TestCurrencyCodeValidation:
 
         with pytest.raises(ValidationError):
             validate_currency_code("US-")  # 許可されていない文字
+
+
+class TestPaginationParamsValidation:
+    """ページネーションパラメータ検証のテスト"""
+
+    def test_valid_pagination_params(self):
+        """正の整数であれば検証を通る"""
+        page, per_page = validate_pagination_params(1, 20)
+        assert page == 1
+        assert per_page == 20
+
+    def test_string_inputs_are_converted(self):
+        """文字列の数値も許容される"""
+        page, per_page = validate_pagination_params("2", "50")
+        assert page == 2
+        assert per_page == 50
+
+    def test_invalid_page_number(self):
+        """無効なページ番号はエラー"""
+        with pytest.raises(ValidationError):
+            validate_pagination_params(0, 10)
+
+        with pytest.raises(ValidationError):
+            validate_pagination_params("invalid", 10)
+
+    def test_invalid_per_page_value(self):
+        """per_page の値が不正な場合"""
+        with pytest.raises(ValidationError):
+            validate_pagination_params(1, 0)
+
+        with pytest.raises(ValidationError):
+            validate_pagination_params(1, "invalid")
+
+    def test_per_page_exceeds_maximum(self):
+        """最大件数を超えた場合はエラー"""
+        with pytest.raises(ValidationError):
+            validate_pagination_params(1, 500, max_per_page=100)

--- a/utils/validators.py
+++ b/utils/validators.py
@@ -120,6 +120,45 @@ def validate_numeric_range(
     return num_value
 
 
+def _to_int(value: Union[str, int, float], field_name: str) -> int:
+    """整数に変換する内部ヘルパー"""
+
+    try:
+        int_value = int(value)
+    except (ValueError, TypeError):
+        raise ValidationError(f"{field_name} must be an integer") from None
+
+    return int_value
+
+
+def validate_pagination_params(
+    page: Union[str, int, float],
+    per_page: Union[str, int, float],
+    *,
+    max_per_page: int = 100,
+) -> tuple[int, int]:
+    """ページネーションパラメータの検証"""
+
+    if max_per_page <= 0:
+        raise ValidationError("max_per_page must be greater than zero")
+
+    page_value = _to_int(page, "page")
+    per_page_value = _to_int(per_page, "per_page")
+
+    if page_value < 1:
+        raise ValidationError("page must be greater than or equal to 1")
+
+    if per_page_value < 1:
+        raise ValidationError("per_page must be greater than or equal to 1")
+
+    if per_page_value > max_per_page:
+        raise ValidationError(
+            f"per_page must be less than or equal to {max_per_page}"
+        )
+
+    return page_value, per_page_value
+
+
 def validate_email(email: str) -> str:
     """メールアドレスの検証
 


### PR DESCRIPTION
## Summary
- add a pagination parameter validator to `utils.validators` to normalize and validate page/per_page inputs
- introduce helper to coerce integers and provide detailed error messages for invalid pagination values
- cover the new validator with unit tests including valid conversions and error cases

## Testing
- pytest tests/test_validators.py::TestPaginationParamsValidation -q

------
https://chatgpt.com/codex/tasks/task_e_68e60ed7a5888321abb1bccadd103702